### PR TITLE
[윤찬호] 3차 과제 제출

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### properties ###
+*.properties

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     //swagger
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.5.0'
     testImplementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-api', version: '2.5.0'
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/cotato/backend/common/cache/CacheConfig.java
+++ b/backend/src/main/java/cotato/backend/common/cache/CacheConfig.java
@@ -1,0 +1,17 @@
+package cotato.backend.common.cache;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CacheConfig {
+
+	@Bean
+	public Map<Long, AtomicInteger> viewCounts() {
+		return new ConcurrentHashMap<>();
+	}
+}

--- a/backend/src/main/java/cotato/backend/common/dto/PageResponse.java
+++ b/backend/src/main/java/cotato/backend/common/dto/PageResponse.java
@@ -1,0 +1,37 @@
+package cotato.backend.common.dto;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PageResponse<T> {
+	private List<T> items;
+	private int currentPage;
+	private int totalPages;
+	private long totalItems;
+
+	private PageResponse(List<T> content, int number, int totalPages, long totalElements) {
+		this.items = content;
+		this.currentPage = number;
+		this.totalPages = totalPages;
+		this.totalItems = totalElements;
+	}
+
+	public static <T> PageResponse<T> from(Page<T> page) {
+		return new PageResponse<>(
+			page.getContent(),
+			page.getNumber(),
+			page.getTotalPages(),
+			page.getTotalElements()
+		);
+	}
+}

--- a/backend/src/main/java/cotato/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/cotato/backend/common/exception/ErrorCode.java
@@ -9,12 +9,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-	//400
+	//Common
 	BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.", "COMMON-001"),
 	INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 잘 못 되었습니다.", "COMMON-002"),
-
-	//500
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에서 에러가 발생하였습니다.", "COMMON-002"),
+
+	//Post
+	POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 POST를 찾을 수 없습니다.", "POST-001"),
 	;
 
 	private final HttpStatus httpStatus;

--- a/backend/src/main/java/cotato/backend/common/redis/RedisCacheConfig.java
+++ b/backend/src/main/java/cotato/backend/common/redis/RedisCacheConfig.java
@@ -1,0 +1,42 @@
+package cotato.backend.common.redis;
+
+import java.time.Duration;
+
+import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching // Spring Boot의 캐싱 설정을 활성화
+public class RedisCacheConfig {
+
+	// 기본 캐시 전략
+	@Bean
+	public RedisCacheConfiguration redisCacheConfiguration() {
+		return RedisCacheConfiguration.defaultCacheConfig()
+			.entryTtl(Duration.ofSeconds(60))
+			.disableCachingNullValues()
+			.serializeKeysWith(
+				RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
+			)
+			.serializeValuesWith(
+				RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())
+			);
+	}
+
+	// 커스텀 캐시 전략
+	@Bean
+	public RedisCacheManagerBuilderCustomizer redisCacheManagerBuilderCustomizer() {
+		return (builder) -> builder
+			.withCacheConfiguration("shortTermCache",
+				RedisCacheConfiguration.defaultCacheConfig()
+					.entryTtl(Duration.ofMinutes(1)) // cache1에 TTL 1분
+					.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+					.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())));
+	}
+}

--- a/backend/src/main/java/cotato/backend/common/redis/RedisConfig.java
+++ b/backend/src/main/java/cotato/backend/common/redis/RedisConfig.java
@@ -1,0 +1,22 @@
+package cotato.backend.common.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+
+	@Value("${spring.data.redis.host}")
+	private String host;
+
+	@Value("${spring.data.redis.port}")
+	private int port;
+
+	@Bean
+	public LettuceConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+	}
+}

--- a/backend/src/main/java/cotato/backend/common/scheduling/SchedulerConfig.java
+++ b/backend/src/main/java/cotato/backend/common/scheduling/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package cotato.backend.common.scheduling;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/backend/src/main/java/cotato/backend/common/scheduling/SchedulerTasks.java
+++ b/backend/src/main/java/cotato/backend/common/scheduling/SchedulerTasks.java
@@ -1,0 +1,33 @@
+package cotato.backend.common.scheduling;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import cotato.backend.domains.post.entity.Post;
+import cotato.backend.domains.post.service.PostService;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SchedulerTasks {
+
+	private final Map<Long, AtomicInteger> viewCounts;
+	private final PostService postService;
+
+	// 조회수 증가를 DB에 반영
+	@Scheduled(fixedRate = 10000) // 매 1분마다 캐시를 DB에 반영
+	@Transactional
+	public void persistViewCounts() {
+		viewCounts.forEach((postId, count) -> {
+			Post post = postService.findById(postId);
+
+			post.setViews(post.getViews() + count.get());
+
+			count.set(0); // 캐시 초기화
+		});
+	}
+}

--- a/backend/src/main/java/cotato/backend/domains/post/Post.java
+++ b/backend/src/main/java/cotato/backend/domains/post/Post.java
@@ -1,6 +1,12 @@
 package cotato.backend.domains.post;
 
+import static jakarta.persistence.GenerationType.*;
+
+import cotato.backend.domains.post.dto.request.SavePostRequest;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,4 +16,39 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post {
 
+	@Id
+	@Column(name = "post_id")
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private String title;
+
+	@Column(nullable = false)
+	private String content;
+
+	@Column(nullable = false)
+	private String name;
+
+	@Column(nullable = false)
+	private Long views;
+
+	public Post(
+		String title,
+		String content,
+		String name
+	) {
+		this.title = title;
+		this.content = content;
+		this.name = name;
+		this.views = 0L;
+	}
+
+	public static Post of(SavePostRequest savePostRequest) {
+		return new Post(
+			savePostRequest.getTitle(),
+			savePostRequest.getContent(),
+			savePostRequest.getName()
+		);
+	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/Post.java
+++ b/backend/src/main/java/cotato/backend/domains/post/Post.java
@@ -44,7 +44,7 @@ public class Post {
 		this.views = 0L;
 	}
 
-	public static Post of(SavePostRequest savePostRequest) {
+	public static Post from(SavePostRequest savePostRequest) {
 		return new Post(
 			savePostRequest.getTitle(),
 			savePostRequest.getContent(),

--- a/backend/src/main/java/cotato/backend/domains/post/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostController.java
@@ -1,9 +1,11 @@
 package cotato.backend.domains.post;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import cotato.backend.common.dto.DataResponse;
@@ -28,6 +30,13 @@ public class PostController {
 	@PostMapping
 	public ResponseEntity<DataResponse<Void>> savePost(@RequestBody SavePostRequest request) {
 		postService.save(request);
+
+		return ResponseEntity.ok(DataResponse.ok());
+	}
+
+	@GetMapping("/{postId}")
+	public ResponseEntity<DataResponse<Void>> findPostById(@RequestParam Long postId) {
+		postService.findPostById(postId);
 
 		return ResponseEntity.ok(DataResponse.ok());
 	}

--- a/backend/src/main/java/cotato/backend/domains/post/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import cotato.backend.common.dto.DataResponse;
+import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.dto.request.SavePostsByExcelRequest;
 import lombok.RequiredArgsConstructor;
 
@@ -20,6 +21,13 @@ public class PostController {
 	@PostMapping("/excel")
 	public ResponseEntity<DataResponse<Void>> savePostsByExcel(@RequestBody SavePostsByExcelRequest request) {
 		postService.saveEstatesByExcel(request.getPath());
+
+		return ResponseEntity.ok(DataResponse.ok());
+	}
+
+	@PostMapping
+	public ResponseEntity<DataResponse<Void>> savePost(@RequestBody SavePostRequest request) {
+		postService.save(request);
 
 		return ResponseEntity.ok(DataResponse.ok());
 	}

--- a/backend/src/main/java/cotato/backend/domains/post/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostService.java
@@ -10,7 +10,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import cotato.backend.common.excel.ExcelUtils;
 import cotato.backend.common.exception.ApiException;
+import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.repository.PostJDBCRepository;
+import cotato.backend.domains.post.repository.PostRepository;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 public class PostService {
 
 	private final PostJDBCRepository postJDBCRepository;
+	private final PostRepository postRepository;
 
 	// 로컬 파일 경로로부터 엑셀 파일을 읽어 Post 엔터티로 변환하고 저장
 	public void saveEstatesByExcel(String filePath) {
@@ -43,5 +46,12 @@ public class PostService {
 			log.error("Failed to save estates by excel", e);
 			throw ApiException.from(INTERNAL_SERVER_ERROR);
 		}
+	}
+
+	// 글 저장
+	public void save(SavePostRequest request) {
+		Post post = Post.from(request);
+
+		postRepository.save(post);
 	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import cotato.backend.common.excel.ExcelUtils;
 import cotato.backend.common.exception.ApiException;
+import cotato.backend.domains.post.repository.PostJDBCRepository;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +20,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 @Transactional
 public class PostService {
+
+	private final PostJDBCRepository postJDBCRepository;
 
 	// 로컬 파일 경로로부터 엑셀 파일을 읽어 Post 엔터티로 변환하고 저장
 	public void saveEstatesByExcel(String filePath) {
@@ -34,6 +37,8 @@ public class PostService {
 				})
 				.collect(Collectors.toList());
 
+			// Post 엔터티를 저장
+			postJDBCRepository.saveAll(posts);
 		} catch (Exception e) {
 			log.error("Failed to save estates by excel", e);
 			throw ApiException.from(INTERNAL_SERVER_ERROR);

--- a/backend/src/main/java/cotato/backend/domains/post/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostService.java
@@ -54,4 +54,9 @@ public class PostService {
 
 		postRepository.save(post);
 	}
+
+	public void findPostById(Long postId) {
+		postRepository.findById(postId)
+			.orElseThrow(() -> ApiException.from(POST_NOT_FOUND));
+	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
@@ -17,6 +17,7 @@ import cotato.backend.domains.post.dto.request.SavePostsByExcelRequest;
 import cotato.backend.domains.post.dto.response.FindPostByIdResponse;
 import cotato.backend.domains.post.dto.response.FindPostsByPopularResponse;
 import cotato.backend.domains.post.service.PostService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -27,14 +28,14 @@ public class PostController {
 	private final PostService postService;
 
 	@PostMapping("/excel")
-	public ResponseEntity<DataResponse<Void>> savePostsByExcel(@RequestBody SavePostsByExcelRequest request) {
+	public ResponseEntity<DataResponse<Void>> savePostsByExcel(@RequestBody @Valid SavePostsByExcelRequest request) {
 		postService.saveEstatesByExcel(request.getPath());
 
 		return ResponseEntity.ok(DataResponse.ok());
 	}
 
 	@PostMapping
-	public ResponseEntity<DataResponse<Void>> savePost(@RequestBody SavePostRequest request) {
+	public ResponseEntity<DataResponse<Void>> savePost(@RequestBody @Valid SavePostRequest request) {
 		postService.save(request);
 
 		return ResponseEntity.ok(DataResponse.ok());

--- a/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
@@ -1,6 +1,7 @@
-package cotato.backend.domains.post;
+package cotato.backend.domains.post.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import cotato.backend.common.dto.DataResponse;
+import cotato.backend.domains.post.service.PostService;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.dto.request.SavePostsByExcelRequest;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +39,13 @@ public class PostController {
 	@GetMapping("/{postId}")
 	public ResponseEntity<DataResponse<Void>> findPostById(@RequestParam Long postId) {
 		postService.findPostById(postId);
+
+		return ResponseEntity.ok(DataResponse.ok());
+	}
+
+	@DeleteMapping("/{postId}")
+	public ResponseEntity<DataResponse<Void>> deletePostById(@RequestParam Long postId) {
+		postService.deletePostById(postId);
 
 		return ResponseEntity.ok(DataResponse.ok());
 	}

--- a/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
@@ -1,5 +1,6 @@
 package cotato.backend.domains.post.controller;
 
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -7,12 +8,14 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import cotato.backend.common.dto.DataResponse;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.dto.request.SavePostsByExcelRequest;
 import cotato.backend.domains.post.dto.response.FindPostByIdResponse;
+import cotato.backend.domains.post.dto.response.FindPostsByPopularResponse;
 import cotato.backend.domains.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 
@@ -49,5 +52,15 @@ public class PostController {
 		postService.deletePostById(postId);
 
 		return ResponseEntity.ok(DataResponse.ok());
+	}
+
+	@GetMapping
+	public ResponseEntity<DataResponse<Page<FindPostsByPopularResponse>>> findPostsByPopular(
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size
+	) {
+		Page<FindPostsByPopularResponse> responses = postService.findPostsByPopular(page, size);
+
+		return ResponseEntity.ok(DataResponse.from(responses));
 	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
@@ -3,16 +3,17 @@ package cotato.backend.domains.post.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import cotato.backend.common.dto.DataResponse;
-import cotato.backend.domains.post.service.PostService;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.dto.request.SavePostsByExcelRequest;
+import cotato.backend.domains.post.dto.response.FindPostByIdResponse;
+import cotato.backend.domains.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -37,14 +38,14 @@ public class PostController {
 	}
 
 	@GetMapping("/{postId}")
-	public ResponseEntity<DataResponse<Void>> findPostById(@RequestParam Long postId) {
-		postService.findPostById(postId);
+	public ResponseEntity<DataResponse<FindPostByIdResponse>> findPostById(@PathVariable Long postId) {
+		FindPostByIdResponse response = postService.findPostById(postId);
 
-		return ResponseEntity.ok(DataResponse.ok());
+		return ResponseEntity.ok(DataResponse.from(response));
 	}
 
 	@DeleteMapping("/{postId}")
-	public ResponseEntity<DataResponse<Void>> deletePostById(@RequestParam Long postId) {
+	public ResponseEntity<DataResponse<Void>> deletePostById(@PathVariable Long postId) {
 		postService.deletePostById(postId);
 
 		return ResponseEntity.ok(DataResponse.ok());

--- a/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
@@ -1,6 +1,5 @@
 package cotato.backend.domains.post.controller;
 
-import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import cotato.backend.common.dto.DataResponse;
+import cotato.backend.common.dto.PageResponse;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.dto.request.SavePostsByExcelRequest;
 import cotato.backend.domains.post.dto.response.FindPostByIdResponse;
@@ -56,11 +56,11 @@ public class PostController {
 	}
 
 	@GetMapping
-	public ResponseEntity<DataResponse<Page<FindPostsByPopularResponse>>> findPostsByPopular(
+	public ResponseEntity<DataResponse<PageResponse<FindPostsByPopularResponse>>> findPostsByPopular(
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "10") int size
 	) {
-		Page<FindPostsByPopularResponse> responses = postService.findPostsByPopular(page, size);
+		PageResponse<FindPostsByPopularResponse> responses = postService.findPostsByPopular(page, size);
 
 		return ResponseEntity.ok(DataResponse.from(responses));
 	}

--- a/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
@@ -43,7 +43,7 @@ public class PostController {
 
 	@GetMapping("/{postId}")
 	public ResponseEntity<DataResponse<FindPostByIdResponse>> findPostById(@PathVariable Long postId) {
-		FindPostByIdResponse response = postService.findPostById(postId);
+		FindPostByIdResponse response = postService.findPostDtoByIdAndIncreaseView(postId);
 
 		return ResponseEntity.ok(DataResponse.from(response));
 	}

--- a/backend/src/main/java/cotato/backend/domains/post/dto/request/SavePostRequest.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/request/SavePostRequest.java
@@ -1,11 +1,17 @@
 package cotato.backend.domains.post.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 @Data
 public class SavePostRequest {
 
+	@NotBlank(message = "제목을 입력해주세요.")
 	private String title;
+
+	@NotBlank(message = "내용을 입력해주세요.")
 	private String content;
+
+	@NotBlank(message = "작성자를 입력해주세요.")
 	private String name;
 }

--- a/backend/src/main/java/cotato/backend/domains/post/dto/request/SavePostRequest.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/request/SavePostRequest.java
@@ -1,0 +1,11 @@
+package cotato.backend.domains.post.dto.request;
+
+import lombok.Data;
+
+@Data
+public class SavePostRequest {
+
+	private String title;
+	private String content;
+	private String name;
+}

--- a/backend/src/main/java/cotato/backend/domains/post/dto/request/SavePostsByExcelRequest.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/request/SavePostsByExcelRequest.java
@@ -5,7 +5,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SavePostsByExcelRequest {
 
 	private String path;

--- a/backend/src/main/java/cotato/backend/domains/post/dto/request/SavePostsByExcelRequest.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/request/SavePostsByExcelRequest.java
@@ -1,5 +1,6 @@
 package cotato.backend.domains.post.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -7,5 +8,6 @@ import lombok.NoArgsConstructor;
 @Data
 public class SavePostsByExcelRequest {
 
+	@NotBlank(message = "파일 경로를 입력해주세요.")
 	private String path;
 }

--- a/backend/src/main/java/cotato/backend/domains/post/dto/response/FindPostByIdResponse.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/response/FindPostByIdResponse.java
@@ -1,0 +1,25 @@
+package cotato.backend.domains.post.dto.response;
+
+import cotato.backend.domains.post.entity.Post;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class FindPostByIdResponse {
+
+	private String title;
+	private String content;
+	private String name;
+	private Long views;
+
+	public static FindPostByIdResponse from(Post post) {
+		return new FindPostByIdResponse(
+			post.getTitle(),
+			post.getContent(),
+			post.getName(),
+			post.getViews()
+		);
+	}
+}

--- a/backend/src/main/java/cotato/backend/domains/post/dto/response/FindPostsByPopularResponse.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/response/FindPostsByPopularResponse.java
@@ -1,0 +1,27 @@
+package cotato.backend.domains.post.dto.response;
+
+import cotato.backend.domains.post.entity.Post;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class FindPostsByPopularResponse {
+
+	private String postId;
+	private String title;
+	private String content;
+	private String name;
+	private Long views;
+
+	public static FindPostsByPopularResponse from(Post post) {
+		return new FindPostsByPopularResponse(
+			post.getId().toString(),
+			post.getTitle(),
+			post.getContent(),
+			post.getName(),
+			post.getViews()
+		);
+	}
+}

--- a/backend/src/main/java/cotato/backend/domains/post/dto/response/FindPostsByPopularResponse.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/response/FindPostsByPopularResponse.java
@@ -4,9 +4,11 @@ import cotato.backend.domains.post.entity.Post;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FindPostsByPopularResponse {
 
 	private String postId;

--- a/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
+++ b/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
@@ -1,4 +1,4 @@
-package cotato.backend.domains.post;
+package cotato.backend.domains.post.entity;
 
 import static jakarta.persistence.GenerationType.*;
 

--- a/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
+++ b/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
@@ -51,4 +51,8 @@ public class Post {
 			savePostRequest.getName()
 		);
 	}
+
+	public void increaseViews() {
+		this.views++;
+	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
+++ b/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
@@ -31,6 +32,7 @@ public class Post {
 	private String name;
 
 	@Column(nullable = false)
+	@Setter
 	private Long views;
 
 	public Post(
@@ -50,9 +52,5 @@ public class Post {
 			savePostRequest.getContent(),
 			savePostRequest.getName()
 		);
-	}
-
-	public void increaseViews() {
-		this.views++;
 	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
+++ b/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
@@ -7,7 +7,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
-import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -34,9 +33,6 @@ public class Post {
 	@Column(nullable = false)
 	private Long views;
 
-	@Version
-	private Long version;
-
 	public Post(
 		String title,
 		String content,
@@ -46,7 +42,6 @@ public class Post {
 		this.content = content;
 		this.name = name;
 		this.views = 0L;
-		this.version = 0L;
 	}
 
 	public static Post from(SavePostRequest savePostRequest) {

--- a/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
+++ b/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -33,6 +34,9 @@ public class Post {
 	@Column(nullable = false)
 	private Long views;
 
+	@Version
+	private Long version;
+
 	public Post(
 		String title,
 		String content,
@@ -42,6 +46,7 @@ public class Post {
 		this.content = content;
 		this.name = name;
 		this.views = 0L;
+		this.version = 0L;
 	}
 
 	public static Post from(SavePostRequest savePostRequest) {

--- a/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
+++ b/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
@@ -2,6 +2,8 @@ package cotato.backend.domains.post.entity;
 
 import static jakarta.persistence.GenerationType.*;
 
+import org.hibernate.annotations.ColumnDefault;
+
 import cotato.backend.domains.post.dto.request.SavePostRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -38,7 +40,8 @@ public class Post {
 
 	@Column(nullable = false)
 	@Setter
-	private Long views;
+	@ColumnDefault("0")
+	private Long views = 0L;
 
 	public Post(
 		String title,
@@ -48,7 +51,6 @@ public class Post {
 		this.title = title;
 		this.content = content;
 		this.name = name;
-		this.views = 0L;
 	}
 
 	public static Post from(SavePostRequest savePostRequest) {

--- a/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
+++ b/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
@@ -7,6 +7,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,6 +16,9 @@ import lombok.Setter;
 
 @Entity
 @Getter
+@Table(name = "post", indexes = {
+	@Index(name = "idx_views", columnList = "views")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post {
 

--- a/backend/src/main/java/cotato/backend/domains/post/repository/PostJDBCRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/repository/PostJDBCRepository.java
@@ -18,7 +18,7 @@ public class PostJDBCRepository {
 
 	@Transactional
 	public void saveAll(List<Post> posts) {
-		String sql = "INSERT INTO post (title, content, name) " +
+		String sql = "INSERT INTO post (title, content, name, views) " +
 			"VALUES (?, ?, ?, ?)";
 
 		jdbcTemplate.batchUpdate(sql,
@@ -28,6 +28,7 @@ public class PostJDBCRepository {
 				ps.setString(1, post.getTitle());
 				ps.setString(2, post.getContent());
 				ps.setString(3, post.getName());
+				ps.setLong(4, post.getViews());
 			});
 	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/repository/PostJDBCRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/repository/PostJDBCRepository.java
@@ -1,0 +1,33 @@
+package cotato.backend.domains.post.repository;
+
+import java.sql.PreparedStatement;
+import java.util.List;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import cotato.backend.domains.post.Post;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class PostJDBCRepository {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	@Transactional
+	public void saveAll(List<Post> posts) {
+		String sql = "INSERT INTO post (title, content, name) " +
+			"VALUES (?, ?, ?, ?)";
+
+		jdbcTemplate.batchUpdate(sql,
+			posts,
+			posts.size(),
+			(PreparedStatement ps, Post post) -> {
+				ps.setString(1, post.getTitle());
+				ps.setString(2, post.getContent());
+				ps.setString(3, post.getName());
+			});
+	}
+}

--- a/backend/src/main/java/cotato/backend/domains/post/repository/PostJDBCRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/repository/PostJDBCRepository.java
@@ -6,7 +6,7 @@ import java.util.List;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-import cotato.backend.domains.post.Post;
+import cotato.backend.domains.post.entity.Post;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 

--- a/backend/src/main/java/cotato/backend/domains/post/repository/PostJDBCRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/repository/PostJDBCRepository.java
@@ -18,8 +18,8 @@ public class PostJDBCRepository {
 
 	@Transactional
 	public void saveAll(List<Post> posts) {
-		String sql = "INSERT INTO post (title, content, name, views, version) " +
-			"VALUES (?, ?, ?, ?, ?)";
+		String sql = "INSERT INTO post (title, content, name, views) " +
+			"VALUES (?, ?, ?, ?)";
 
 		jdbcTemplate.batchUpdate(sql,
 			posts,
@@ -29,7 +29,6 @@ public class PostJDBCRepository {
 				ps.setString(2, post.getContent());
 				ps.setString(3, post.getName());
 				ps.setLong(4, post.getViews());
-				ps.setLong(5, post.getVersion());
 			});
 	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/repository/PostJDBCRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/repository/PostJDBCRepository.java
@@ -18,8 +18,8 @@ public class PostJDBCRepository {
 
 	@Transactional
 	public void saveAll(List<Post> posts) {
-		String sql = "INSERT INTO post (title, content, name, views) " +
-			"VALUES (?, ?, ?, ?)";
+		String sql = "INSERT INTO post (title, content, name, views, version) " +
+			"VALUES (?, ?, ?, ?, ?)";
 
 		jdbcTemplate.batchUpdate(sql,
 			posts,
@@ -29,6 +29,7 @@ public class PostJDBCRepository {
 				ps.setString(2, post.getContent());
 				ps.setString(3, post.getName());
 				ps.setLong(4, post.getViews());
+				ps.setLong(5, post.getVersion());
 			});
 	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/repository/PostRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/repository/PostRepository.java
@@ -2,7 +2,7 @@ package cotato.backend.domains.post.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import cotato.backend.domains.post.Post;
+import cotato.backend.domains.post.entity.Post;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 }

--- a/backend/src/main/java/cotato/backend/domains/post/repository/PostRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/repository/PostRepository.java
@@ -1,8 +1,12 @@
 package cotato.backend.domains.post.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import cotato.backend.domains.post.entity.Post;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+	Page<Post> findAllByOrderByViewsDesc(Pageable pageable);
 }

--- a/backend/src/main/java/cotato/backend/domains/post/repository/PostRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/repository/PostRepository.java
@@ -1,0 +1,8 @@
+package cotato.backend.domains.post.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import cotato.backend.domains.post.Post;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/backend/src/main/java/cotato/backend/domains/post/repository/PostRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/repository/PostRepository.java
@@ -1,12 +1,20 @@
 package cotato.backend.domains.post.repository;
 
+import static jakarta.persistence.LockModeType.*;
+
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
 import cotato.backend.domains.post.entity.Post;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
 	Page<Post> findAllByOrderByViewsDesc(Pageable pageable);
+
+	@Lock(PESSIMISTIC_WRITE)
+	Optional<Post> findById(Long id);
 }

--- a/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import cotato.backend.common.excel.ExcelUtils;
 import cotato.backend.common.exception.ApiException;
+import cotato.backend.domains.post.dto.response.FindPostByIdResponse;
 import cotato.backend.domains.post.entity.Post;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.repository.PostJDBCRepository;
@@ -57,9 +58,11 @@ public class PostService {
 	}
 
 	// 글 조회
-	public void findPostById(Long postId) {
-		postRepository.findById(postId)
+	public FindPostByIdResponse findPostById(Long postId) {
+		Post post = postRepository.findById(postId)
 			.orElseThrow(() -> ApiException.from(POST_NOT_FOUND));
+
+		return FindPostByIdResponse.from(post);
 	}
 
 	// 글 삭제

--- a/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
@@ -76,4 +76,13 @@ public class PostService {
 	public void deletePostById(Long postId) {
 		postRepository.deleteById(postId);
 	}
+
+	// 글목록 인기순 조회
+	public Page<FindPostsByPopularResponse> findPostsByPopular(int page, int size) {
+		PageRequest pageRequest = PageRequest.of(page, size);
+
+		Page<Post> posts = postRepository.findAllByOrderByViewsDesc(pageRequest);
+
+		return posts.map(FindPostsByPopularResponse::from);
+	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
@@ -22,13 +22,14 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-@Transactional
+@Transactional(readOnly = true)
 public class PostService {
 
 	private final PostJDBCRepository postJDBCRepository;
 	private final PostRepository postRepository;
 
 	// 로컬 파일 경로로부터 엑셀 파일을 읽어 Post 엔터티로 변환하고 저장
+	@Transactional
 	public void saveEstatesByExcel(String filePath) {
 		try {
 			// 엑셀 파일을 읽어 데이터 프레임 형태로 변환
@@ -51,6 +52,7 @@ public class PostService {
 	}
 
 	// 글 저장
+	@Transactional
 	public void save(SavePostRequest request) {
 		Post post = Post.from(request);
 
@@ -58,14 +60,19 @@ public class PostService {
 	}
 
 	// 글 조회
+	@Transactional
 	public FindPostByIdResponse findPostById(Long postId) {
 		Post post = postRepository.findById(postId)
 			.orElseThrow(() -> ApiException.from(POST_NOT_FOUND));
+
+		// 조회수 증가
+		post.increaseViews();
 
 		return FindPostByIdResponse.from(post);
 	}
 
 	// 글 삭제
+	@Transactional
 	public void deletePostById(Long postId) {
 		postRepository.deleteById(postId);
 	}

--- a/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
@@ -1,4 +1,4 @@
-package cotato.backend.domains.post;
+package cotato.backend.domains.post.service;
 
 import static cotato.backend.common.exception.ErrorCode.*;
 
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import cotato.backend.common.excel.ExcelUtils;
 import cotato.backend.common.exception.ApiException;
+import cotato.backend.domains.post.entity.Post;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.repository.PostJDBCRepository;
 import cotato.backend.domains.post.repository.PostRepository;
@@ -55,8 +56,14 @@ public class PostService {
 		postRepository.save(post);
 	}
 
+	// 글 조회
 	public void findPostById(Long postId) {
 		postRepository.findById(postId)
 			.orElseThrow(() -> ApiException.from(POST_NOT_FOUND));
+	}
+
+	// 글 삭제
+	public void deletePostById(Long postId) {
+		postRepository.deleteById(postId);
 	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
@@ -7,16 +7,15 @@ import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import cotato.backend.common.excel.ExcelUtils;
 import cotato.backend.common.exception.ApiException;
+import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.dto.response.FindPostByIdResponse;
 import cotato.backend.domains.post.dto.response.FindPostsByPopularResponse;
 import cotato.backend.domains.post.entity.Post;
-import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.repository.PostJDBCRepository;
 import cotato.backend.domains.post.repository.PostRepository;
 import lombok.AccessLevel;
@@ -31,8 +30,6 @@ public class PostService {
 
 	private final PostJDBCRepository postJDBCRepository;
 	private final PostRepository postRepository;
-
-	private static final int MAX_RETRIES = 3;
 
 	// 로컬 파일 경로로부터 엑셀 파일을 읽어 Post 엔터티로 변환하고 저장
 	@Transactional
@@ -73,32 +70,9 @@ public class PostService {
 			.orElseThrow(() -> ApiException.from(POST_NOT_FOUND));
 
 		// 조회수 증가
-		safeIncreaseViews(post);
+		post.increaseViews();
 
 		return FindPostByIdResponse.from(post);
-	}
-
-	private void safeIncreaseViews(Post post) {
-		int attempt = 0;
-		boolean success = false;
-
-		while (attempt < MAX_RETRIES && !success) {
-			try {
-				attempt++;
-
-				// 조회수 증가
-				post.increaseViews();
-
-				postRepository.save(post);
-				success = true; // 저장 성공 시 반복문 종료
-			} catch (ObjectOptimisticLockingFailureException e) {
-				if (attempt >= MAX_RETRIES) {
-					throw ApiException.from(INTERNAL_SERVER_ERROR);
-				}
-				// 로그 출력
-				System.out.println("Optimistic lock exception on attempt " + attempt + ". Retrying...");
-			}
-		}
 	}
 
 	// 글 삭제

--- a/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
@@ -5,12 +5,16 @@ import static cotato.backend.common.exception.ErrorCode.*;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import cotato.backend.common.excel.ExcelUtils;
 import cotato.backend.common.exception.ApiException;
 import cotato.backend.domains.post.dto.response.FindPostByIdResponse;
+import cotato.backend.domains.post.dto.response.FindPostsByPopularResponse;
 import cotato.backend.domains.post.entity.Post;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.repository.PostJDBCRepository;
@@ -27,6 +31,8 @@ public class PostService {
 
 	private final PostJDBCRepository postJDBCRepository;
 	private final PostRepository postRepository;
+
+	private static final int MAX_RETRIES = 3;
 
 	// 로컬 파일 경로로부터 엑셀 파일을 읽어 Post 엔터티로 변환하고 저장
 	@Transactional
@@ -59,6 +65,7 @@ public class PostService {
 		postRepository.save(post);
 	}
 
+
 	// 글 조회
 	@Transactional
 	public FindPostByIdResponse findPostById(Long postId) {
@@ -66,9 +73,32 @@ public class PostService {
 			.orElseThrow(() -> ApiException.from(POST_NOT_FOUND));
 
 		// 조회수 증가
-		post.increaseViews();
+		safeIncreaseViews(post);
 
 		return FindPostByIdResponse.from(post);
+	}
+
+	private void safeIncreaseViews(Post post) {
+		int attempt = 0;
+		boolean success = false;
+
+		while (attempt < MAX_RETRIES && !success) {
+			try {
+				attempt++;
+
+				// 조회수 증가
+				post.increaseViews();
+
+				postRepository.save(post);
+				success = true; // 저장 성공 시 반복문 종료
+			} catch (ObjectOptimisticLockingFailureException e) {
+				if (attempt >= MAX_RETRIES) {
+					throw ApiException.from(INTERNAL_SERVER_ERROR);
+				}
+				// 로그 출력
+				System.out.println("Optimistic lock exception on attempt " + attempt + ". Retrying...");
+			}
+		}
 	}
 
 	// 글 삭제

--- a/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
@@ -7,11 +7,13 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import cotato.backend.common.dto.PageResponse;
 import cotato.backend.common.excel.ExcelUtils;
 import cotato.backend.common.exception.ApiException;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
@@ -90,12 +92,13 @@ public class PostService {
 	}
 
 	// 글목록 인기순 조회
-	public Page<FindPostsByPopularResponse> findPostsByPopular(int page, int size) {
+	@Cacheable(cacheNames = "shortTermCache", key = "'posts:page:' + #page + ':size:' + #size")
+	public PageResponse<FindPostsByPopularResponse> findPostsByPopular(int page, int size) {
 		PageRequest pageRequest = PageRequest.of(page, size);
 
 		Page<Post> posts = postRepository.findAllByOrderByViewsDesc(pageRequest);
 
-		return posts.map(FindPostsByPopularResponse::from);
+		return PageResponse.from(posts.map(FindPostsByPopularResponse::from));
 	}
 
 	// 글 조회

--- a/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
@@ -3,6 +3,8 @@ package cotato.backend.domains.post.service;
 import static cotato.backend.common.exception.ErrorCode.*;
 
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
@@ -30,6 +32,7 @@ public class PostService {
 
 	private final PostJDBCRepository postJDBCRepository;
 	private final PostRepository postRepository;
+	private final Map<Long, AtomicInteger> viewCounts;
 
 	// 로컬 파일 경로로부터 엑셀 파일을 읽어 Post 엔터티로 변환하고 저장
 	@Transactional
@@ -62,17 +65,22 @@ public class PostService {
 		postRepository.save(post);
 	}
 
-
 	// 글 조회
 	@Transactional
-	public FindPostByIdResponse findPostById(Long postId) {
+	public FindPostByIdResponse findPostDtoByIdAndIncreaseView(Long postId) {
 		Post post = postRepository.findById(postId)
 			.orElseThrow(() -> ApiException.from(POST_NOT_FOUND));
 
 		// 조회수 증가
-		post.increaseViews();
+		incrementViewCountInCache(postId);
 
 		return FindPostByIdResponse.from(post);
+	}
+
+	// 조회수 증가
+	private void incrementViewCountInCache(Long postId) {
+		viewCounts.computeIfAbsent(postId, id -> new AtomicInteger(0))
+			.incrementAndGet();
 	}
 
 	// 글 삭제
@@ -88,5 +96,11 @@ public class PostService {
 		Page<Post> posts = postRepository.findAllByOrderByViewsDesc(pageRequest);
 
 		return posts.map(FindPostsByPopularResponse::from);
+	}
+
+	// 글 조회
+	public Post findById(Long postId) {
+		return postRepository.findById(postId)
+			.orElseThrow(() -> ApiException.from(POST_NOT_FOUND));
 	}
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=backend


### PR DESCRIPTION
## 구현 의도
 최대한 심플하게 구현하려 했습니다.

## 구현 사항
### 엑셀 저장 
단순히 `postRepository.saveAll(posts);`메서드를 호출했을 때에는 
![image](https://github.com/user-attachments/assets/1592e9cd-6871-4ec5-907b-76acbbe46468)
약 68초가 걸렸습니다.
이를 Bulk Insert 방식으로 변경했고 
![image](https://github.com/user-attachments/assets/1e7c0bd6-e1ac-45aa-bb11-b3d4cd8f6ef5)

![image](https://github.com/user-attachments/assets/6d0c27fc-5b8a-4d8f-a667-ecdf72353fa7)
대략 4분의 1정도로 시간이 감소하게 되었습니다.

### Post 생성
![image](https://github.com/user-attachments/assets/1b72a6c3-9451-403d-a272-b09317caebbb)
글 저장은 Post에서 정적 팩터리 메서드를 활용했습니다.

![image](https://github.com/user-attachments/assets/a60c2a90-55aa-4b66-8f8b-66137d5050b6)
위와 같이 생성자와 별개로 DTO를 매개변수로 받는 메서드를 만들면 추후 유지보수가 훨 쉬워지더라구요
그리고 기본 값들은 생성자에서 주도록 했습니다.

### 글 조회
![image](https://github.com/user-attachments/assets/a5b1be91-54b9-452b-9939-17cec7690360)
글 조회 로직은 조회 -> 조회 수 증가로 구현했습니다.

다만, 나중에는 조회 수 증가로직을 별도로 분리하지 않을까 싶어요.
아니면 조회 수 증가 로직만 비동기로 처리해서 조회 성능에 영향을 줄일까 싶습니다.

그리고 이 코드는 레이스 컨디션 문제를 내포하고 있습니다.
두 트랜잭션이 동시에 db에서 데이터를 가져온다면 
둘 다 조회수가 같은 상태가 됩니다.

그럼 업데이트 후에는 +2가 되어야 하는데 +1이 됩니다.

그래서 추후 비관적 락 or 낙관적 락을 활용하여 동시성 문제를 해결해보려 합니다.

### 글삭제
![image](https://github.com/user-attachments/assets/4310d1b3-85e8-4fbb-ac77-c0678b34b693)
평범한 방식으로 글을 삭제했습니다.

### 인기 게시글목록 조회
![image](https://github.com/user-attachments/assets/a797ea3e-f7c7-4732-ae54-00d69c0fc4d0)
페이지네이션을 활용하여 인기 게시글을 조회했습니다.
인기순 내림차순으로 조회하기 위해 JpaRepository를 활용했습니다.

다만 매번 인기순으로 조회를 하면 모든 게시글을 조회해 찾아야 하므로 O(n)이 무조건 걸리게 됩니다.

이걸 Indexing을 활용해 O(lonN)으로 바꿔볼 예정입니다.

또한 가능하다면 Redis  Cache를 활용해 인기 게시글 목록은 Cache에 저장해두려 합니다.   

## 참고 사항
## 아쉬운 점
- 조회 수 증가로직으로 인한 약간의 성능 문제
- 인기 게시글 목록 성능 문제


## 여러분들에게 궁금한 점
다들 유효성 검사는 Entity 단에서 하시나요 Dto or Service 단에서 하시나요?
아니면 둘 다?

요즘 느끼는 게 Entity 단에서 처리하면, 테스트 코드 작성할 때 Entity 생성 유효성 검사 테스트가 훨 쉬워지더라구요.

반면에 Service 단에서 처리하면, 메서드 자체를 테스트해야 해서 테스트가 어려워지구요.
Dto에서 처리하면 막상 엔티티 생성할 때 제대로 들어가는 지 판단이 어렵구요.

Entity에서 처리하려 했는데 Validation을 사용할 수 없어 다들 직접 작성하나 궁금합니다!