### PR TITLE
[오치현] 4차 과제 제출

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+application.*
 
 ### STS ###
 .apt_generated

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/backend/src/main/java/cotato/backend/common/dto/DataResponse.java
+++ b/backend/src/main/java/cotato/backend/common/dto/DataResponse.java
@@ -24,4 +24,8 @@ public class DataResponse<T> extends BaseResponse {
 	public static <T> DataResponse<Void> ok() {
 		return new DataResponse<>(HttpStatus.OK, null);
 	}
+
+	public static <T> DataResponse<Void> created() {
+		return new DataResponse<>(HttpStatus.CREATED, null);
+	}
 }

--- a/backend/src/main/java/cotato/backend/common/dto/ErrorResponse.java
+++ b/backend/src/main/java/cotato/backend/common/dto/ErrorResponse.java
@@ -1,7 +1,6 @@
 package cotato.backend.common.dto;
 
-import java.util.List;
-
+import java.util.Map;
 import org.springframework.http.HttpStatus;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -14,14 +13,14 @@ import lombok.Getter;
 public class ErrorResponse extends BaseResponse {
 
 	private final String message;
-	private final List<String> reasons;
+	private final Map<String, String> reasons;
 	private final String code;
 
 	private ErrorResponse(
 		HttpStatus status,
 		String message,
 		String code,
-		List<String> reasons
+		Map<String, String> reasons
 	) {
 		super(status);
 		this.message = message;
@@ -42,7 +41,7 @@ public class ErrorResponse extends BaseResponse {
 		return new ErrorResponse(httpStatus, message, code, null);
 	}
 
-	public static ErrorResponse of(ErrorCode errorCode, List<String> reasons) {
+	public static ErrorResponse of(ErrorCode errorCode, Map<String, String> reasons) {
 		HttpStatus status = errorCode.getHttpStatus();
 		String message = errorCode.getMessage();
 		String code = errorCode.getCode();

--- a/backend/src/main/java/cotato/backend/common/exception/ApiException.java
+++ b/backend/src/main/java/cotato/backend/common/exception/ApiException.java
@@ -10,25 +10,17 @@ public class ApiException extends RuntimeException {
 	private final HttpStatus httpStatus;
 	private final String code;
 
-	public ApiException(
-		HttpStatus httpStatus,
-		String message,
-		String code
+	private ApiException(
+			final HttpStatus httpStatus,
+			final String message,
+			final String code
 	) {
 		super(message);
 		this.httpStatus = httpStatus;
 		this.code = code;
 	}
 
-	public static ApiException from(ErrorCode errorCode) {
+	public static ApiException from(final ErrorCode errorCode) {
 		return new ApiException(errorCode.getHttpStatus(), errorCode.getMessage(), errorCode.getCode());
-	}
-
-	public static ApiException of(
-		HttpStatus httpStatus,
-		String message,
-		String code
-	) {
-		return new ApiException(httpStatus, message, code);
 	}
 }

--- a/backend/src/main/java/cotato/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/cotato/backend/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package cotato.backend.common.exception;
 
+import cotato.backend.domains.post.exception.PostException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -19,9 +20,16 @@ public class GlobalExceptionHandler {
 		return makeErrorResponseEntity(e.getHttpStatus(), e.getMessage(), e.getCode());
 	}
 
+	@ExceptionHandler(PostException.class)
+	public ResponseEntity<Object> handlePostException(PostException e) {
+		log.warn("handlePostException", e);
+
+		return makeErrorResponseEntity(e.getHttpStatus(), e.getMessage(), e.getCode());
+	}
+
 	private ResponseEntity<Object> makeErrorResponseEntity(HttpStatus httpStatus, String message, String code) {
 		return ResponseEntity
-			.status(httpStatus)
-			.body(ErrorResponse.of(httpStatus, message, code));
+				.status(httpStatus)
+				.body(ErrorResponse.of(httpStatus, message, code));
 	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/Post.java
+++ b/backend/src/main/java/cotato/backend/domains/post/Post.java
@@ -1,13 +1,55 @@
 package cotato.backend.domains.post;
 
+import cotato.backend.domains.post.dto.PostDTO;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
-@Getter
+@Getter @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id")
+    private Long id;
 
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column
+    private long views;
+
+    private Post(
+            final String title,
+            final String content,
+            final String name,
+            final long views
+    ) {
+        this.title = title;
+        this.content = content;
+        this.name = name;
+        this.views = views;
+    }
+
+    public static Post toPost(final PostDTO postDTO) {
+        return new Post(
+                postDTO.title(),
+                postDTO.content(),
+                postDTO.name(),
+                postDTO.views()
+        );
+    }
 }

--- a/backend/src/main/java/cotato/backend/domains/post/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostController.java
@@ -2,11 +2,15 @@ package cotato.backend.domains.post;
 
 import cotato.backend.domains.post.dto.PostDTO;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
+import cotato.backend.domains.post.dto.response.PostDetailResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import cotato.backend.common.dto.DataResponse;
@@ -32,5 +36,13 @@ public class PostController {
 		postService.savePost(PostDTO.toPostDTO(savePostRequest));
 
 		return ResponseEntity.ok(DataResponse.ok());
+	}
+
+	@GetMapping("/{id}")
+	public ResponseEntity<DataResponse<PostDetailResponse>> getPost(final @PathVariable("id") long id) {
+		final PostDTO postDTO = postService.findPostById(id);
+		final PostDetailResponse postDetailResponse = PostDetailResponse.toPostDetailResponse(postDTO);
+
+		return ResponseEntity.ok(DataResponse.from(postDetailResponse));
 	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostController.java
@@ -1,5 +1,7 @@
 package cotato.backend.domains.post;
 
+import cotato.backend.domains.post.dto.PostDTO;
+import cotato.backend.domains.post.dto.request.SavePostRequest;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,8 +21,15 @@ public class PostController {
 	private final PostService postService;
 
 	@PostMapping("/excel")
-	public ResponseEntity<DataResponse<Void>> savePostsByExcel(@RequestBody @Valid SavePostsByExcelRequest request) {
+	public ResponseEntity<DataResponse<Void>> savePostsByExcel(final @RequestBody @Valid SavePostsByExcelRequest request) {
 		postService.saveEstatesByExcel(request.path());
+
+		return ResponseEntity.ok(DataResponse.ok());
+	}
+
+	@PostMapping
+	public ResponseEntity<DataResponse<Void>> savePost(final @RequestBody @Valid SavePostRequest savePostRequest) {
+		postService.savePost(PostDTO.toPostDTO(savePostRequest));
 
 		return ResponseEntity.ok(DataResponse.ok());
 	}

--- a/backend/src/main/java/cotato/backend/domains/post/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostController.java
@@ -1,8 +1,10 @@
 package cotato.backend.domains.post;
 
 import cotato.backend.domains.post.dto.PostDTO;
+import cotato.backend.domains.post.dto.PostListDTO;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.dto.response.PostDetailResponse;
+import cotato.backend.domains.post.dto.response.PostListResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -31,6 +33,14 @@ public class PostController {
 		postService.saveEstatesByExcel(request.path());
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(DataResponse.created());
+	}
+
+	@GetMapping
+	public ResponseEntity<DataResponse<PostListResponse>> getPosts(final @RequestParam(required = false, defaultValue = "0") int page) {
+		PostListDTO postListDTO = postService.getPosts(page);
+		PostListResponse postListResponse = PostListResponse.toPostListResponse(postListDTO);
+
+		return ResponseEntity.ok(DataResponse.from(postListResponse));
 	}
 
 	@PostMapping

--- a/backend/src/main/java/cotato/backend/domains/post/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostController.java
@@ -4,6 +4,7 @@ import cotato.backend.domains.post.dto.PostDTO;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.dto.response.PostDetailResponse;
 import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,14 +30,14 @@ public class PostController {
 	public ResponseEntity<DataResponse<Void>> savePostsByExcel(final @RequestBody @Valid SavePostsByExcelRequest request) {
 		postService.saveEstatesByExcel(request.path());
 
-		return ResponseEntity.ok(DataResponse.ok());
+		return ResponseEntity.status(HttpStatus.CREATED).body(DataResponse.created());
 	}
 
 	@PostMapping
 	public ResponseEntity<DataResponse<Void>> savePost(final @RequestBody @Valid SavePostRequest savePostRequest) {
 		postService.savePost(PostDTO.toPostDTO(savePostRequest));
 
-		return ResponseEntity.ok(DataResponse.ok());
+		return ResponseEntity.status(HttpStatus.CREATED).body(DataResponse.created());
 	}
 
 	@GetMapping("/{id}")

--- a/backend/src/main/java/cotato/backend/domains/post/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostController.java
@@ -5,6 +5,7 @@ import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.dto.response.PostDetailResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -44,5 +45,12 @@ public class PostController {
 		final PostDetailResponse postDetailResponse = PostDetailResponse.toPostDetailResponse(postDTO);
 
 		return ResponseEntity.ok(DataResponse.from(postDetailResponse));
+	}
+
+	@DeleteMapping("/{id}")
+	public ResponseEntity<DataResponse<Void>> deletePost(final @PathVariable("id") long id) {
+		postService.deletePostById(id);
+
+		return ResponseEntity.ok(DataResponse.ok());
 	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostController.java
@@ -1,5 +1,6 @@
 package cotato.backend.domains.post;
 
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,8 +19,8 @@ public class PostController {
 	private final PostService postService;
 
 	@PostMapping("/excel")
-	public ResponseEntity<DataResponse<Void>> savePostsByExcel(@RequestBody SavePostsByExcelRequest request) {
-		postService.saveEstatesByExcel(request.getPath());
+	public ResponseEntity<DataResponse<Void>> savePostsByExcel(@RequestBody @Valid SavePostsByExcelRequest request) {
+		postService.saveEstatesByExcel(request.path());
 
 		return ResponseEntity.ok(DataResponse.ok());
 	}

--- a/backend/src/main/java/cotato/backend/domains/post/PostRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostRepository.java
@@ -1,0 +1,6 @@
+package cotato.backend.domains.post;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/backend/src/main/java/cotato/backend/domains/post/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostService.java
@@ -3,6 +3,8 @@ package cotato.backend.domains.post;
 import static cotato.backend.common.exception.ErrorCode.*;
 
 import cotato.backend.domains.post.dto.PostDTO;
+import cotato.backend.domains.post.exception.PostErrorCode;
+import cotato.backend.domains.post.exception.PostException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -19,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostService {
+	private static final long INCREASE_VIEWS_AMOUNT = 1L;
 
 	private final PostRepository postRepository;
 
@@ -43,5 +46,18 @@ public class PostService {
 	@Transactional
 	public void savePost(final PostDTO postDTO) {
 		postRepository.save(Post.toPost(postDTO));
+	}
+
+	// 전달받은 id 값으로 Post 엔티티를 조회하고, PostDTO로 변환해 반환
+	// 조회 성공 시, views 값을 1 늘려줌
+	@Transactional
+	public PostDTO findPostById(final long id) {
+		Post foundPost = postRepository.findById(id).orElseThrow(
+				() -> PostException.from(PostErrorCode.NOT_EXIST)
+		);
+
+		foundPost.setViews(foundPost.getViews() + INCREASE_VIEWS_AMOUNT);
+
+		return PostDTO.toPostDTO(foundPost);
 	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostService.java
@@ -60,4 +60,16 @@ public class PostService {
 
 		return PostDTO.toPostDTO(foundPost);
 	}
+
+	// 전달받은 id 값으로 Post 엔티티를 조회하고, 있다면 삭제
+	// 없다면 에러를 반환
+	@Transactional
+	public void deletePostById(final long id) {
+		// 대상 게시글이 없다면 에러 반환
+		if (!postRepository.existsById(id)) {
+			throw PostException.from(PostErrorCode.NOT_EXIST);
+		}
+
+		postRepository.deleteById(id);
+	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostService.java
@@ -2,6 +2,7 @@ package cotato.backend.domains.post;
 
 import static cotato.backend.common.exception.ErrorCode.*;
 
+import cotato.backend.domains.post.dto.PostDTO;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -20,20 +21,18 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional
 public class PostService {
 
+	private final PostRepository postRepository;
+
 	// 로컬 파일 경로로부터 엑셀 파일을 읽어 Post 엔터티로 변환하고 저장
-	public void saveEstatesByExcel(String filePath) {
+	public void saveEstatesByExcel(final String filePath) {
 		try {
 			// 엑셀 파일을 읽어 데이터 프레임 형태로 변환
 			List<Post> posts = ExcelUtils.parseExcelFile(filePath).stream()
-				.map(row -> {
-					String title = row.get("title");
-					String content = row.get("content");
-					String name = row.get("name");
+					.map(PostDTO::toPostDTO)
+					.map(Post::toPost)
+					.toList();
 
-					return new Post(title, content, name);
-				})
-				.collect(Collectors.toList());
-
+			postRepository.saveAll(posts);
 		} catch (Exception e) {
 			log.error("Failed to save estates by excel", e);
 			throw ApiException.from(INTERNAL_SERVER_ERROR);

--- a/backend/src/main/java/cotato/backend/domains/post/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostService.java
@@ -18,12 +18,12 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-@Transactional
 public class PostService {
 
 	private final PostRepository postRepository;
 
 	// 로컬 파일 경로로부터 엑셀 파일을 읽어 Post 엔터티로 변환하고 저장
+	@Transactional
 	public void saveEstatesByExcel(final String filePath) {
 		try {
 			// 엑셀 파일을 읽어 데이터 프레임 형태로 변환
@@ -37,5 +37,11 @@ public class PostService {
 			log.error("Failed to save estates by excel", e);
 			throw ApiException.from(INTERNAL_SERVER_ERROR);
 		}
+	}
+
+	// 전달받은 값으로 Post 엔티티로 변환하고 저장
+	@Transactional
+	public void savePost(final PostDTO postDTO) {
+		postRepository.save(Post.toPost(postDTO));
 	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostService.java
@@ -7,9 +7,7 @@ import cotato.backend.domains.post.dto.PostListDTO;
 import cotato.backend.domains.post.exception.PostErrorCode;
 import cotato.backend.domains.post.exception.PostException;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;

--- a/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
@@ -1,10 +1,11 @@
-package cotato.backend.domains.post;
+package cotato.backend.domains.post.controller;
 
 import cotato.backend.domains.post.dto.PostDTO;
 import cotato.backend.domains.post.dto.PostListDTO;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.dto.response.PostDetailResponse;
 import cotato.backend.domains.post.dto.response.PostListResponse;
+import cotato.backend.domains.post.service.PostService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
@@ -5,7 +5,7 @@ import cotato.backend.domains.post.dto.PostListDTO;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.dto.response.PostDetailResponse;
 import cotato.backend.domains.post.dto.response.PostListResponse;
-import cotato.backend.domains.post.service.PostService;
+import cotato.backend.domains.post.facade.PostFacade;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,18 +27,18 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PostController {
 
-	private final PostService postService;
+	private final PostFacade postFacade;
 
 	@PostMapping("/excel")
 	public ResponseEntity<DataResponse<Void>> savePostsByExcel(final @RequestBody @Valid SavePostsByExcelRequest request) {
-		postService.saveEstatesByExcel(request.path());
+		postFacade.saveEstatesByExcel(request.path());
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(DataResponse.created());
 	}
 
 	@GetMapping
 	public ResponseEntity<DataResponse<PostListResponse>> getPosts(final @RequestParam(required = false, defaultValue = "0") int page) {
-		PostListDTO postListDTO = postService.getPosts(page);
+		PostListDTO postListDTO = postFacade.getPosts(page);
 		PostListResponse postListResponse = PostListResponse.toPostListResponse(postListDTO);
 
 		return ResponseEntity.ok(DataResponse.from(postListResponse));
@@ -46,14 +46,14 @@ public class PostController {
 
 	@PostMapping
 	public ResponseEntity<DataResponse<Void>> savePost(final @RequestBody @Valid SavePostRequest savePostRequest) {
-		postService.savePost(PostDTO.toPostDTO(savePostRequest));
+		postFacade.savePost(PostDTO.toPostDTO(savePostRequest));
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(DataResponse.created());
 	}
 
 	@GetMapping("/{id}")
 	public ResponseEntity<DataResponse<PostDetailResponse>> getPost(final @PathVariable("id") long id) {
-		final PostDTO postDTO = postService.findPostByIdWithPessimisticLock(id);
+		final PostDTO postDTO = postFacade.findPostByIdWithOptimisticLock(id);
 		final PostDetailResponse postDetailResponse = PostDetailResponse.toPostDetailResponse(postDTO);
 
 		return ResponseEntity.ok(DataResponse.from(postDetailResponse));
@@ -61,7 +61,7 @@ public class PostController {
 
 	@DeleteMapping("/{id}")
 	public ResponseEntity<DataResponse<Void>> deletePost(final @PathVariable("id") long id) {
-		postService.deletePostById(id);
+		postFacade.deletePostById(id);
 
 		return ResponseEntity.ok(DataResponse.ok());
 	}

--- a/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
@@ -5,7 +5,7 @@ import cotato.backend.domains.post.dto.PostListDTO;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.dto.response.PostDetailResponse;
 import cotato.backend.domains.post.dto.response.PostListResponse;
-import cotato.backend.domains.post.facade.PostFacade;
+import cotato.backend.domains.post.service.PostService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,18 +27,18 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PostController {
 
-	private final PostFacade postFacade;
+	private final PostService postService;
 
 	@PostMapping("/excel")
 	public ResponseEntity<DataResponse<Void>> savePostsByExcel(final @RequestBody @Valid SavePostsByExcelRequest request) {
-		postFacade.saveEstatesByExcel(request.path());
+		postService.saveEstatesByExcel(request.path());
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(DataResponse.created());
 	}
 
 	@GetMapping
 	public ResponseEntity<DataResponse<PostListResponse>> getPosts(final @RequestParam(required = false, defaultValue = "0") int page) {
-		PostListDTO postListDTO = postFacade.getPosts(page);
+		PostListDTO postListDTO = postService.getPosts(page);
 		PostListResponse postListResponse = PostListResponse.toPostListResponse(postListDTO);
 
 		return ResponseEntity.ok(DataResponse.from(postListResponse));
@@ -46,14 +46,14 @@ public class PostController {
 
 	@PostMapping
 	public ResponseEntity<DataResponse<Void>> savePost(final @RequestBody @Valid SavePostRequest savePostRequest) {
-		postFacade.savePost(PostDTO.toPostDTO(savePostRequest));
+		postService.savePost(PostDTO.toPostDTO(savePostRequest));
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(DataResponse.created());
 	}
 
 	@GetMapping("/{id}")
 	public ResponseEntity<DataResponse<PostDetailResponse>> getPost(final @PathVariable("id") long id) {
-		final PostDTO postDTO = postFacade.findPostById(id);
+		final PostDTO postDTO = postService.findPostByIdWithPessimisticLock(id);
 		final PostDetailResponse postDetailResponse = PostDetailResponse.toPostDetailResponse(postDTO);
 
 		return ResponseEntity.ok(DataResponse.from(postDetailResponse));
@@ -61,7 +61,7 @@ public class PostController {
 
 	@DeleteMapping("/{id}")
 	public ResponseEntity<DataResponse<Void>> deletePost(final @PathVariable("id") long id) {
-		postFacade.deletePostById(id);
+		postService.deletePostById(id);
 
 		return ResponseEntity.ok(DataResponse.ok());
 	}

--- a/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
@@ -5,7 +5,7 @@ import cotato.backend.domains.post.dto.PostListDTO;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.dto.response.PostDetailResponse;
 import cotato.backend.domains.post.dto.response.PostListResponse;
-import cotato.backend.domains.post.service.PostService;
+import cotato.backend.domains.post.facade.PostFacade;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,18 +27,18 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PostController {
 
-	private final PostService postService;
+	private final PostFacade postFacade;
 
 	@PostMapping("/excel")
 	public ResponseEntity<DataResponse<Void>> savePostsByExcel(final @RequestBody @Valid SavePostsByExcelRequest request) {
-		postService.saveEstatesByExcel(request.path());
+		postFacade.saveEstatesByExcel(request.path());
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(DataResponse.created());
 	}
 
 	@GetMapping
 	public ResponseEntity<DataResponse<PostListResponse>> getPosts(final @RequestParam(required = false, defaultValue = "0") int page) {
-		PostListDTO postListDTO = postService.getPosts(page);
+		PostListDTO postListDTO = postFacade.getPosts(page);
 		PostListResponse postListResponse = PostListResponse.toPostListResponse(postListDTO);
 
 		return ResponseEntity.ok(DataResponse.from(postListResponse));
@@ -46,14 +46,14 @@ public class PostController {
 
 	@PostMapping
 	public ResponseEntity<DataResponse<Void>> savePost(final @RequestBody @Valid SavePostRequest savePostRequest) {
-		postService.savePost(PostDTO.toPostDTO(savePostRequest));
+		postFacade.savePost(PostDTO.toPostDTO(savePostRequest));
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(DataResponse.created());
 	}
 
 	@GetMapping("/{id}")
 	public ResponseEntity<DataResponse<PostDetailResponse>> getPost(final @PathVariable("id") long id) {
-		final PostDTO postDTO = postService.findPostById(id);
+		final PostDTO postDTO = postFacade.findPostById(id);
 		final PostDetailResponse postDetailResponse = PostDetailResponse.toPostDetailResponse(postDTO);
 
 		return ResponseEntity.ok(DataResponse.from(postDetailResponse));
@@ -61,7 +61,7 @@ public class PostController {
 
 	@DeleteMapping("/{id}")
 	public ResponseEntity<DataResponse<Void>> deletePost(final @PathVariable("id") long id) {
-		postService.deletePostById(id);
+		postFacade.deletePostById(id);
 
 		return ResponseEntity.ok(DataResponse.ok());
 	}

--- a/backend/src/main/java/cotato/backend/domains/post/dto/PostDTO.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/PostDTO.java
@@ -1,5 +1,6 @@
 package cotato.backend.domains.post.dto;
 
+import cotato.backend.domains.post.Post;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
 import java.util.Map;
 
@@ -32,6 +33,16 @@ public record PostDTO (
                 savePostRequest.content(),
                 savePostRequest.name(),
                 DEFAULT_VIEWS
+        );
+    }
+
+    public static PostDTO toPostDTO(final Post post) {
+        return new PostDTO(
+                post.getId(),
+                post.getTitle(),
+                post.getContent(),
+                post.getName(),
+                post.getViews()
         );
     }
 }

--- a/backend/src/main/java/cotato/backend/domains/post/dto/PostDTO.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/PostDTO.java
@@ -1,6 +1,6 @@
 package cotato.backend.domains.post.dto;
 
-import cotato.backend.domains.post.Post;
+import cotato.backend.domains.post.entity.Post;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
 import java.util.Map;
 

--- a/backend/src/main/java/cotato/backend/domains/post/dto/PostDTO.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/PostDTO.java
@@ -1,5 +1,6 @@
 package cotato.backend.domains.post.dto;
 
+import cotato.backend.domains.post.dto.request.SavePostRequest;
 import java.util.Map;
 
 public record PostDTO (
@@ -20,6 +21,16 @@ public record PostDTO (
                 parsedData.get(TITLE),
                 parsedData.get(CONTENT),
                 parsedData.get(NAME),
+                DEFAULT_VIEWS
+        );
+    }
+
+    public static PostDTO toPostDTO(final SavePostRequest savePostRequest) {
+        return new PostDTO(
+                null,
+                savePostRequest.title(),
+                savePostRequest.content(),
+                savePostRequest.name(),
                 DEFAULT_VIEWS
         );
     }

--- a/backend/src/main/java/cotato/backend/domains/post/dto/PostDTO.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/PostDTO.java
@@ -1,0 +1,26 @@
+package cotato.backend.domains.post.dto;
+
+import java.util.Map;
+
+public record PostDTO (
+        Long id,
+        String title,
+        String content,
+        String name,
+        Long views
+) {
+    private static final String TITLE = "title";
+    private static final String CONTENT = "content";
+    private static final String NAME = "name";
+    private static final long DEFAULT_VIEWS = 0L;
+
+    public static PostDTO toPostDTO(final Map<String, String> parsedData) {
+        return new PostDTO(
+                null,
+                parsedData.get(TITLE),
+                parsedData.get(CONTENT),
+                parsedData.get(NAME),
+                DEFAULT_VIEWS
+        );
+    }
+}

--- a/backend/src/main/java/cotato/backend/domains/post/dto/PostListDTO.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/PostListDTO.java
@@ -1,6 +1,6 @@
 package cotato.backend.domains.post.dto;
 
-import cotato.backend.domains.post.Post;
+import cotato.backend.domains.post.entity.Post;
 import java.util.List;
 import org.springframework.data.domain.Page;
 

--- a/backend/src/main/java/cotato/backend/domains/post/dto/PostListDTO.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/PostListDTO.java
@@ -1,0 +1,23 @@
+package cotato.backend.domains.post.dto;
+
+import cotato.backend.domains.post.Post;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record PostListDTO(
+        int currentPage,
+        int totalPage,
+        List<PostDTO> postDTOs
+) {
+    public static PostListDTO toPostListDTO(final Page<Post> posts) {
+        List<PostDTO> postDTOS = posts.get()
+                .map(PostDTO::toPostDTO)
+                .toList();
+
+        return new PostListDTO(
+                posts.getNumber(),
+                posts.getTotalPages(),
+                postDTOS
+        );
+    }
+}

--- a/backend/src/main/java/cotato/backend/domains/post/dto/request/SavePostRequest.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/request/SavePostRequest.java
@@ -1,0 +1,13 @@
+package cotato.backend.domains.post.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SavePostRequest(
+        @NotBlank(message = "제목은 필수 입력 값입니다.")
+        String title,
+        @NotBlank(message = " 내용은 필수 입력 값입니다.")
+        String content,
+        @NotBlank(message = "이름은 필수 입력 값입니다.")
+        String name
+) {
+}

--- a/backend/src/main/java/cotato/backend/domains/post/dto/request/SavePostsByExcelRequest.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/request/SavePostsByExcelRequest.java
@@ -1,12 +1,9 @@
 package cotato.backend.domains.post.dto.request;
 
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
 
-@Data
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class SavePostsByExcelRequest {
-
-	private String path;
+public record SavePostsByExcelRequest (
+		@NotBlank(message = "경로는 공백이 될 수 없습니다.")
+		String path
+) {
 }

--- a/backend/src/main/java/cotato/backend/domains/post/dto/response/PostDetailResponse.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/response/PostDetailResponse.java
@@ -1,0 +1,19 @@
+package cotato.backend.domains.post.dto.response;
+
+import cotato.backend.domains.post.dto.PostDTO;
+
+public record PostDetailResponse(
+        String title,
+        String content,
+        String name,
+        long views
+) {
+    public static PostDetailResponse toPostDetailResponse(final PostDTO postDTO) {
+        return new PostDetailResponse(
+                postDTO.title(),
+                postDTO.content(),
+                postDTO.name(),
+                postDTO.views()
+        );
+    }
+}

--- a/backend/src/main/java/cotato/backend/domains/post/dto/response/PostListResponse.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/response/PostListResponse.java
@@ -1,0 +1,23 @@
+package cotato.backend.domains.post.dto.response;
+
+import cotato.backend.domains.post.dto.PostDTO;
+import cotato.backend.domains.post.dto.PostListDTO;
+import java.util.List;
+
+public record PostListResponse(
+        int currentPage,
+        int totalPage,
+        List<PostResponse> postResponses
+) {
+    public static PostListResponse toPostListResponse(final PostListDTO postListDTO) {
+        List<PostResponse> postResponses = postListDTO.postDTOs().stream()
+                .map(PostResponse::toPostResponse)
+                .toList();
+
+        return new PostListResponse(
+                postListDTO.currentPage(),
+                postListDTO.totalPage(),
+                postResponses
+        );
+    }
+}

--- a/backend/src/main/java/cotato/backend/domains/post/dto/response/PostListResponse.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/response/PostListResponse.java
@@ -1,6 +1,5 @@
 package cotato.backend.domains.post.dto.response;
 
-import cotato.backend.domains.post.dto.PostDTO;
 import cotato.backend.domains.post.dto.PostListDTO;
 import java.util.List;
 

--- a/backend/src/main/java/cotato/backend/domains/post/dto/response/PostResponse.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/response/PostResponse.java
@@ -1,0 +1,17 @@
+package cotato.backend.domains.post.dto.response;
+
+import cotato.backend.domains.post.dto.PostDTO;
+
+public record PostResponse(
+        long id,
+        String title,
+        String name
+) {
+    public static PostResponse toPostResponse(final PostDTO postDTO) {
+        return new PostResponse(
+                postDTO.id(),
+                postDTO.title(),
+                postDTO.name()
+        );
+    }
+}

--- a/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
+++ b/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
@@ -1,4 +1,4 @@
-package cotato.backend.domains.post;
+package cotato.backend.domains.post.entity;
 
 import cotato.backend.domains.post.dto.PostDTO;
 import jakarta.persistence.Column;

--- a/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
+++ b/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -31,6 +32,9 @@ public class Post {
 
     @Column
     private long views;
+
+    @Version
+    private Long version;
 
     private Post(
             final String title,

--- a/backend/src/main/java/cotato/backend/domains/post/exception/PostErrorCode.java
+++ b/backend/src/main/java/cotato/backend/domains/post/exception/PostErrorCode.java
@@ -1,0 +1,15 @@
+package cotato.backend.domains.post.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostErrorCode {
+    NOT_EXIST(HttpStatus.BAD_REQUEST, "존재하지 않는 게시글입니다.", "POST-001");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final String code;
+}

--- a/backend/src/main/java/cotato/backend/domains/post/exception/PostException.java
+++ b/backend/src/main/java/cotato/backend/domains/post/exception/PostException.java
@@ -1,0 +1,29 @@
+package cotato.backend.domains.post.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class PostException extends RuntimeException {
+
+    private final HttpStatus httpStatus;
+    private final String code;
+
+    private PostException(
+            final HttpStatus httpStatus,
+            final String message,
+            final String code
+    ) {
+        super(message);
+        this.httpStatus = httpStatus;
+        this.code = code;
+    }
+
+    public static PostException from(final PostErrorCode postErrorCode) {
+        return new PostException(
+                postErrorCode.getHttpStatus(),
+                postErrorCode.getMessage(),
+                postErrorCode.getCode()
+        );
+    }
+}

--- a/backend/src/main/java/cotato/backend/domains/post/facade/PostFacade.java
+++ b/backend/src/main/java/cotato/backend/domains/post/facade/PostFacade.java
@@ -4,6 +4,7 @@ import cotato.backend.domains.post.dto.PostDTO;
 import cotato.backend.domains.post.dto.PostListDTO;
 import cotato.backend.domains.post.service.PostService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -11,19 +12,24 @@ import org.springframework.stereotype.Component;
 public class PostFacade {
     private final PostService postService;
 
-
     public void saveEstatesByExcel(final String filePath) {
         postService.saveEstatesByExcel(filePath);
     }
-
 
     public void savePost(final PostDTO postDTO) {
         postService.savePost(postDTO);
     }
 
-
     public synchronized PostDTO findPostById(final long id) {
         return postService.findPostById(id);
+    }
+
+    public PostDTO findPostByIdWithOptimisticLock(final long id) {
+        try {
+            return postService.findPostByIdWithOptimisticLock(id);
+        } catch (final OptimisticLockingFailureException e) {
+            return findPostByIdWithOptimisticLock(id);
+        }
     }
 
     public void deletePostById(final long id) {

--- a/backend/src/main/java/cotato/backend/domains/post/facade/PostFacade.java
+++ b/backend/src/main/java/cotato/backend/domains/post/facade/PostFacade.java
@@ -1,0 +1,36 @@
+package cotato.backend.domains.post.facade;
+
+import cotato.backend.domains.post.dto.PostDTO;
+import cotato.backend.domains.post.dto.PostListDTO;
+import cotato.backend.domains.post.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PostFacade {
+    private final PostService postService;
+
+
+    public void saveEstatesByExcel(final String filePath) {
+        postService.saveEstatesByExcel(filePath);
+    }
+
+
+    public void savePost(final PostDTO postDTO) {
+        postService.savePost(postDTO);
+    }
+
+
+    public synchronized PostDTO findPostById(final long id) {
+        return postService.findPostById(id);
+    }
+
+    public void deletePostById(final long id) {
+        postService.deletePostById(id);
+    }
+
+    public PostListDTO getPosts(final int page) {
+        return postService.getPosts(page);
+    }
+}

--- a/backend/src/main/java/cotato/backend/domains/post/repository/ExcelBatchRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/repository/ExcelBatchRepository.java
@@ -1,0 +1,39 @@
+package cotato.backend.domains.post.repository;
+
+import cotato.backend.domains.post.entity.Post;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class ExcelBatchRepository {
+
+    private static final int BATCH_SIZE = 500;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public void saveAllPosts(List<Post> posts) {
+        jdbcTemplate.batchUpdate(
+                "INSERT INTO post (title, content, name, views) VALUES (?, ?, ?, ?)",
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        ps.setString(1, posts.get(i).getTitle());
+                        ps.setString(2, posts.get(i).getContent());
+                        ps.setString(3, posts.get(i).getName());
+                        ps.setLong(4, posts.get(i).getViews());
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return BATCH_SIZE;
+                    }
+                }
+        );
+    }
+}

--- a/backend/src/main/java/cotato/backend/domains/post/repository/PostRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/repository/PostRepository.java
@@ -1,7 +1,15 @@
 package cotato.backend.domains.post.repository;
 
 import cotato.backend.domains.post.entity.Post;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("FROM Post WHERE id=:postId")
+    Optional<Post> findByIdWithPessimisticLock(@Param("postId") final long postId);
 }

--- a/backend/src/main/java/cotato/backend/domains/post/repository/PostRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/repository/PostRepository.java
@@ -1,5 +1,6 @@
-package cotato.backend.domains.post;
+package cotato.backend.domains.post.repository;
 
+import cotato.backend.domains.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostRepository extends JpaRepository<Post, Long> {

--- a/backend/src/main/java/cotato/backend/domains/post/repository/PostRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/repository/PostRepository.java
@@ -12,4 +12,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("FROM Post WHERE id=:postId")
     Optional<Post> findByIdWithPessimisticLock(@Param("postId") final long postId);
+
+    @Lock(LockModeType.OPTIMISTIC)
+    @Query("FROM Post WHERE id=:postId")
+    Optional<Post> findByIdWithOptimisticLock(@Param("postId") final long postId);
 }

--- a/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
@@ -99,6 +99,18 @@ public class PostService {
 		return PostDTO.toPostDTO(foundPost);
 	}
 
+	// findPostById 함수의 동시성 문제 해결 버전 - Optimistic Lock
+	@Transactional
+	public PostDTO findPostByIdWithOptimisticLock(final long id) {
+		Post foundPost = postRepository.findByIdWithOptimisticLock(id).orElseThrow(
+				() -> PostException.from(PostErrorCode.NOT_EXIST)
+		);
+
+		foundPost.setViews(foundPost.getViews() + INCREASE_VIEWS_AMOUNT);
+
+		return PostDTO.toPostDTO(foundPost);
+	}
+
 	// 전달받은 id 값으로 Post 엔티티를 조회하고, 있다면 삭제
 	// 없다면 에러를 반환
 	@Transactional

--- a/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
@@ -87,6 +87,18 @@ public class PostService {
 		return PostDTO.toPostDTO(foundPost);
 	}
 
+	// findPostById 함수의 동시성 문제 해결 버전 - Pessimistic Lock
+	@Transactional
+	public PostDTO findPostByIdWithPessimisticLock(final long id) {
+		Post foundPost = postRepository.findByIdWithPessimisticLock(id).orElseThrow(
+				() -> PostException.from(PostErrorCode.NOT_EXIST)
+		);
+
+		foundPost.setViews(foundPost.getViews() + INCREASE_VIEWS_AMOUNT);
+
+		return PostDTO.toPostDTO(foundPost);
+	}
+
 	// 전달받은 id 값으로 Post 엔티티를 조회하고, 있다면 삭제
 	// 없다면 에러를 반환
 	@Transactional

--- a/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
@@ -1,7 +1,9 @@
-package cotato.backend.domains.post;
+package cotato.backend.domains.post.service;
 
 import static cotato.backend.common.exception.ErrorCode.*;
 
+import cotato.backend.domains.post.entity.Post;
+import cotato.backend.domains.post.repository.PostRepository;
 import cotato.backend.domains.post.dto.PostDTO;
 import cotato.backend.domains.post.dto.PostListDTO;
 import cotato.backend.domains.post.exception.PostErrorCode;

--- a/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
@@ -3,6 +3,7 @@ package cotato.backend.domains.post.service;
 import static cotato.backend.common.exception.ErrorCode.*;
 
 import cotato.backend.domains.post.entity.Post;
+import cotato.backend.domains.post.repository.ExcelBatchRepository;
 import cotato.backend.domains.post.repository.PostRepository;
 import cotato.backend.domains.post.dto.PostDTO;
 import cotato.backend.domains.post.dto.PostListDTO;
@@ -32,6 +33,7 @@ public class PostService {
 	private static final int PAGE_SIZE = 10;
 
 	private final PostRepository postRepository;
+	private final ExcelBatchRepository excelBatchRepository;
 
 	@Transactional(readOnly = true)
 	protected Sort getSort() {
@@ -59,7 +61,7 @@ public class PostService {
 					.map(Post::toPost)
 					.toList();
 
-			postRepository.saveAll(posts);
+			excelBatchRepository.saveAllPosts(posts);
 		} catch (Exception e) {
 			log.error("Failed to save estates by excel", e);
 			throw ApiException.from(INTERNAL_SERVER_ERROR);

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=backend


### PR DESCRIPTION
[노션 링크](https://honorable-farm-d82.notion.site/168b96b19b2680308163e030d1df39bd?pvs=4)

# 스프링에서의 동시성 제어

스프링 코드 레벨에서의 동시성 제어에 관해 알아보는 시간을 가졌습니다.

모두 공통적으로 “/api/posts/1” 으로 1000번의 GET 요청을 수행했습니다. 이때 조회 수가 5000이어야 정상입니다.

## 1. Synchronized

자바의 `synchronized` 키워드는 N 개의 스레드가 공유 자원에 접근하는 것을 제어해 동시성 제어 메커니즘을 제공한다. 이때 `synchronized` 키워드가 적용된 곳을 `Critical Section` 이라고 부르는데, `Monitor Locking` 메커니즘을 이용해서 제어한다.

<aside>

자바의 모든 객체는 `Monitor Lock` 을 가지고 있고, 이를 통해 스레드 동기화를 수행할 수 있다. `synchronized` 키워드로 상호 배제(Mutual Exclusion) 을 보장한다.

→ 한 번에 하나의 스레드만 Critical Section에 접근할 수 있게 만든다.

</aside>

> synchronized 키워드 적용
> 

![image](https://github.com/user-attachments/assets/9f632f77-d9f4-4458-b2d2-bdd525dd63ce)

![image](https://github.com/user-attachments/assets/470e95aa-dad9-44ea-acff-d2297041814b)

synchronized 키워드를 적용했음에도 조회수가 530 밖에 되지않는다.

이유는 `트랜잭션의 커밋 시점과 모니터 언락 시점의 불일치` 때문이다.  `@Transactional` 어노테이션이 붙은 클래스는 GCLIB에 의해 런타임에 기반 프록시가 생성되고, 로직으로 진입 전/후에 Transaction Begin과 Commit/Rollback이 처리된다.

![image](https://github.com/user-attachments/assets/f395d75c-5c32-4cd8-913b-8494a4781276)

따라서 모니터 락의 언락 시점을 트랜잭션 커밋 이후로 바꾸면 된다. 파사드 계층을 추가해 해결할 수 있다. 

> synchronized + facade layer 적용
> 

![image](https://github.com/user-attachments/assets/74e3b629-8e83-4c92-bf2a-eed956818fdd)

![image](https://github.com/user-attachments/assets/f6ecab1d-6b41-44dd-aacd-3098e607a117)

정상적으로 1001개 (1000번 요청 + 마지막 1번 조회)가 조회되는 것을 볼 수 있다.

단점은 분산 환경에서 동시성 문제가 해결되지 않는다. (Scale Out)

→ 분산 환경에서의 동시성 제어는 다음 항목으로 해결 가능하다.

1. 데이터베이스의 레코드에 직접적으로 Lock 적용 (`Pessimistic Lock`)
2. 애플리케이션 레벨에서 버전을 통해 갱신 시점에 동기화 (`Optimistic Lock`)
3. 별도의 영역에서 Lock이라는 “개념”을 관리
    - MySQL Named Lock
    - Redis
    - Zookeeper

출처 : [https://sjiwon-dev.tistory.com/20](https://sjiwon-dev.tistory.com/20)

## 2. Pessimistic Lock

DB의 Lock 기능을 이용하고, `SELECT FOR UPDATE` 구문이 사용된다.

트랜잭션 커밋 전 미리 트랜잭션 충돌을 감지할 수 있다. 또한 Lock을 획득할 때까지 트랜잭션은 대기하므로, Timeout을 설정할 수 있다.

<aside>

`SELECT FOR UPDATE` 를 사용할 경우 Gap Lock이 사용된다.

이는 MySQL의 특별한 형태의 잠금인데, 실제 존재하지 않는 레코드 공간(간격)을 잠근다.

나중에 더 깊게 공부 : https://medium.com/daangn/mysql-gap-lock-%EB%8B%A4%EC%8B%9C%EB%B3%B4%EA%B8%B0-7f47ea3f68bc + 리마큐

</aside>

> Pessimistic Lock 적용
> 

![image](https://github.com/user-attachments/assets/36e836d5-502f-4d2b-b2e3-7bf819e5d34c)

![image](https://github.com/user-attachments/assets/354af266-1931-4439-ad95-1679eb59e5f5)

정상적으로 조회되는 모습을 볼 수 있다.

단점은 다음과 같다.

1. 항상 Exclusive Lock을 걸고 사용하기 때문에 수행 시간이 늘어난다.
2. MVCC를 통해서 데이터를 읽을 때 데드락이 발생할 확률이 높다.
3. 스레드 고갈이 일어날 수 있다. (DB 커넥션 기다리는 시간이 늘어남) → 늘리면 되긴 함(물리적 한계)

## 3. Optimistic Lock

MVCC와 비슷한 원리로 동작하고, 애플리케이션 레벨에서 버전 컬럼을 사용해 읽어온 시점과 트랜잭션이 커밋되는 시점의 데이터가 같은지 정합성을 비교한다.

<aside>

MVCC?

동시성 제어 방법 중 하나인 `Locking` 의 성능 저하 문제점을 해결하기 위해 나온 개념이다.

Multi-Version Conccurency Control 의 약자로 원본의 데이터와 변경중인 데이터를 동시에 유지하는 방식을 채택한다. 사용자가 데이터에 접근하면 데이터베이스의 `스냅샷` 을 읽고, 변경 중에 롤백되면 원본 데이터의 `스냅샷` 으로 복구한다. 변경에 성공하면 `스냅샷` 을 디스크에 반영한다.

버전 관리의 경우, 기존 데이터를 덮어 씌우는 방식이 아닌, 기존 데이터를 바탕으로 이전 버전과 비교해 변경된 내용을 기록한다. 하나의 데이터에는 여러 버전의 데이터가 존재하고 사용자는 마지막 데이터의 버전을 읽는다.

</aside>

> Optimistic Lock 적용
> 

![image](https://github.com/user-attachments/assets/12e8a12f-db00-44a6-bfd0-6b2c8d9fe947)

Post 엔티티 클래스에 `@Version` 어노테이션을 추가한다.

이를 통해 손쉽게 버전을 자동으로 비교 및 증가시켜준다.

![image](https://github.com/user-attachments/assets/f2e162c6-55ba-41a7-b4f2-e5b0d6ea986b)

![image](https://github.com/user-attachments/assets/c9810978-47c4-460b-89eb-26e73cea5cd2)

Optimistic Lock은 동시성 이슈만 감지 가능하므로 정상적으로 처리하길 기대한다면, 예외가 감지됐을 때 재시도를 해야한다. 이를 위해 파사드 클래스를 사용해 Service의 조회 로직을 재귀 처리했다.

![image](https://github.com/user-attachments/assets/9ff978d7-09a9-420b-a1de-cfcacc00837b)

정상적으로 조회되는 모습을 볼 수 있다.

단점은 다음과 같다.

1. 충돌이 발생하면 기다리는게 아니라 재시도 하기 때문에 느리다.
2. 낮은 확률로 스택 오버플로우가 발생할 수 있다. (굳이 단점은 아니라고 한다.)

## 더 공부해볼 것

1. 이외의 Lock 방식
2. 근본적인 동작 원리
3. MVCC
4. Gap Lock
5. 각 Lock의 데드락 발생 상황, 해결 방법
6. Named Lock, Redis 활용 Lock, 실제 분산 환경에서 테스트
7. 리마큐

## 출처
- [https://mangkyu.tistory.com/53](https://mangkyu.tistory.com/53)
- [https://velog.io/@znftm97/%EB%8F%99%EC%8B%9C%EC%84%B1-%EB%AC%B8%EC%A0%9C-%ED%95%B4%EA%B2%B0%ED%95%98%EA%B8%B0-V2-%EB%B9%84%EA%B4%80%EC%A0%81-%EB%9D%BDPessimistic-Lock](https://velog.io/@znftm97/%EB%8F%99%EC%8B%9C%EC%84%B1-%EB%AC%B8%EC%A0%9C-%ED%95%B4%EA%B2%B0%ED%95%98%EA%B8%B0-V2-%EB%B9%84%EA%B4%80%EC%A0%81-%EB%9D%BDPessimistic-Lock)
- [https://sjiwon-dev.tistory.com/20](https://sjiwon-dev.tistory.com/20)
- [https://velog.io/@nuyh99/%EC%8A%A4%ED%94%84%EB%A7%81%EC%97%90%EC%84%9C-%EB%8F%99%EC%8B%9C%EC%84%B1-%EB%AC%B8%EC%A0%9C%EB%A5%BC-%ED%95%B4%EA%B2%B0%ED%95%98%EB%8A%94-5%EA%B0%80%EC%A7%80-%EB%B0%A9%EB%B2%95](https://velog.io/@nuyh99/%EC%8A%A4%ED%94%84%EB%A7%81%EC%97%90%EC%84%9C-%EB%8F%99%EC%8B%9C%EC%84%B1-%EB%AC%B8%EC%A0%9C%EB%A5%BC-%ED%95%B4%EA%B2%B0%ED%95%98%EB%8A%94-5%EA%B0%80%EC%A7%80-%EB%B0%A9%EB%B2%95)
- [https://curiousjinan.tistory.com/entry/mac-m1-jmeter-setup-and-testing](https://curiousjinan.tistory.com/entry/mac-m1-jmeter-setup-and-testing)
- [https://sjiwon-dev.tistory.com/20](https://sjiwon-dev.tistory.com/20)