### PR TITLE
[전규진] 4차 과제 제출

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -25,6 +25,7 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
+src/main/resources/application.properties
 
 ### NetBeans ###
 /nbproject/private/

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -25,7 +25,7 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
-src/main/resources/application.properties
+application.properties
 
 ### NetBeans ###
 /nbproject/private/

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -26,7 +26,7 @@ application.properties
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
-
+backend/src/main/resources/application.properties
 
 ### NetBeans ###
 /nbproject/private/

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -25,7 +25,7 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
-application.properties
+/application.properties
 
 ### NetBeans ###
 /nbproject/private/

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -18,7 +18,7 @@ bin/
 !**/src/test/**/bin/
 
 ### IntelliJ IDEA ###
-application.properties
+backend/src/main/resources/application.properties
 .idea
 *.iws
 *.iml
@@ -26,7 +26,7 @@ application.properties
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
-backend/src/main/resources/application.properties
+
 
 ### NetBeans ###
 /nbproject/private/

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -18,6 +18,7 @@ bin/
 !**/src/test/**/bin/
 
 ### IntelliJ IDEA ###
+application.properties
 .idea
 *.iws
 *.iml
@@ -25,7 +26,7 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
-/application.properties
+
 
 ### NetBeans ###
 /nbproject/private/

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/backend/src/main/java/cotato/backend/common/dto/DataResponse.java
+++ b/backend/src/main/java/cotato/backend/common/dto/DataResponse.java
@@ -24,4 +24,8 @@ public class DataResponse<T> extends BaseResponse {
 	public static <T> DataResponse<Void> ok() {
 		return new DataResponse<>(HttpStatus.OK, null);
 	}
+
+	public static <T> DataResponse<String> success(String message) {
+		return new DataResponse<>(HttpStatus.OK, message);
+	}
 }

--- a/backend/src/main/java/cotato/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/cotato/backend/common/exception/ErrorCode.java
@@ -13,6 +13,8 @@ public enum ErrorCode {
 	BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.", "COMMON-001"),
 	INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 잘 못 되었습니다.", "COMMON-002"),
 
+	//404
+	NOT_VALID_ERROR(HttpStatus.NOT_FOUND, "값이 유효하지 않습니다", "COMMON-001"),
 	//500
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에서 에러가 발생하였습니다.", "COMMON-002"),
 	;

--- a/backend/src/main/java/cotato/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/cotato/backend/common/exception/GlobalExceptionHandler.java
@@ -13,10 +13,10 @@ import lombok.extern.slf4j.Slf4j;
 public class GlobalExceptionHandler {
 
 	@ExceptionHandler(ApiException.class)
-	public ResponseEntity<Object> handleApiException(ApiException e) {
+	public ResponseEntity<String> handleApiException(ApiException e) {
 		log.warn("handleApiException", e);
 
-		return makeErrorResponseEntity(e.getHttpStatus(), e.getMessage(), e.getCode());
+		return ResponseEntity.status(e.getHttpStatus()).body(e.getMessage());
 	}
 
 	private ResponseEntity<Object> makeErrorResponseEntity(HttpStatus httpStatus, String message, String code) {

--- a/backend/src/main/java/cotato/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/cotato/backend/common/exception/GlobalExceptionHandler.java
@@ -1,7 +1,10 @@
 package cotato.backend.common.exception;
 
+import static cotato.backend.common.exception.ErrorCode.*;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -18,6 +21,13 @@ public class GlobalExceptionHandler {
 
 		return ResponseEntity.status(e.getHttpStatus()).body(e.getMessage());
 	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<String> MethodArgumentNotValidException(MethodArgumentNotValidException ex){
+		ApiException api = ApiException.from(NOT_VALID_ERROR);
+		return ResponseEntity.status(api.getHttpStatus()).body(api.getMessage());
+	}
+
 
 	private ResponseEntity<Object> makeErrorResponseEntity(HttpStatus httpStatus, String message, String code) {
 		return ResponseEntity

--- a/backend/src/main/java/cotato/backend/domains/post/BatchRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/BatchRepository.java
@@ -1,0 +1,38 @@
+package cotato.backend.domains.post;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class BatchRepository {
+	private final JdbcTemplate jdbcTemplate;
+
+	public void insert(List<Post> postList) {
+
+		String itemSql = "INSERT INTO post (title, content, name) VALUES (?, ?, ?)";
+
+		jdbcTemplate.batchUpdate(itemSql, new BatchPreparedStatementSetter() {
+
+			@Override
+			public void setValues(PreparedStatement ps, int i) throws SQLException {
+
+				Post post = postList.get(i);
+				ps.setString(1, post.getTitle());
+				ps.setString(2, post.getContent());
+				ps.setString(3, post.getName());
+			}
+
+			@Override
+			public int getBatchSize() {
+				return postList.size();
+			}
+		});
+	}
+}

--- a/backend/src/main/java/cotato/backend/domains/post/Post.java
+++ b/backend/src/main/java/cotato/backend/domains/post/Post.java
@@ -1,13 +1,43 @@
 package cotato.backend.domains.post;
 
+import org.hibernate.annotations.ColumnDefault;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.stereotype.Service;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post {
 
+	@Id@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private String title;
+
+	@Column(nullable = false)
+	private String content;
+
+	@Column(nullable = false)
+	private String name;
+
+	@ColumnDefault("0")
+	private int views;
+
+	public Post(String title, String content, String name) {
+		this.title = title;
+		this.content = content;
+		this.name = name;
+	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/Post.java
+++ b/backend/src/main/java/cotato/backend/domains/post/Post.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/backend/src/main/java/cotato/backend/domains/post/Post.java
+++ b/backend/src/main/java/cotato/backend/domains/post/Post.java
@@ -10,13 +10,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
+
+
 
 @Entity
 @Getter
-@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post {
 
@@ -40,4 +41,9 @@ public class Post {
 		this.content = content;
 		this.name = name;
 	}
+
+	public void update(int views){
+		this.views += views;
+	}
+
 }

--- a/backend/src/main/java/cotato/backend/domains/post/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import cotato.backend.common.dto.DataResponse;
 import cotato.backend.domains.post.dto.request.SavePostsByExcelRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -35,7 +36,7 @@ public class PostController {
 	}
 
 	@PostMapping("/single")
-	public ResponseEntity<DataResponse<Void>> savePostBySingle(@RequestBody PostDTO postDTO){
+	public ResponseEntity<DataResponse<Void>> savePostBySingle(@Valid@RequestBody PostDTO postDTO){
 		postService.savePostBySingle(postDTO);
 
 		return ResponseEntity.ok(DataResponse.ok());

--- a/backend/src/main/java/cotato/backend/domains/post/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostController.java
@@ -1,11 +1,18 @@
 package cotato.backend.domains.post;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import cotato.backend.common.dto.DataResponse;
@@ -39,4 +46,26 @@ public class PostController {
 
 		return ResponseEntity.ok(post);
 	}
+
+	@GetMapping("/readByViews")
+	public ResponseEntity<Map<String, Object>> readByView(@RequestParam(defaultValue = "0") int page){
+		int size = 10;
+		Page<Post> postPage = postService.getPosts(page, size);
+		List<Map<String, Object>> filteredPosts = postPage.getContent().stream().map(post -> {
+			Map<String, Object> postMap = new HashMap<>();
+			postMap.put("id", post.getId());
+			postMap.put("title", post.getTitle());
+			postMap.put("name", post.getName());
+			return postMap;
+		}).collect(Collectors.toList());
+
+		Map<String, Object> response = new HashMap<>();
+		response.put("posts", filteredPosts); // 게시글 리스트
+		response.put("currentPage", postPage.getNumber()); // 현재 페이지
+		response.put("totalPages", postPage.getTotalPages());
+
+		return ResponseEntity.ok(response);
+	}
+
+
 }

--- a/backend/src/main/java/cotato/backend/domains/post/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostController.java
@@ -42,14 +42,14 @@ public class PostController {
 		return ResponseEntity.ok(DataResponse.ok());
 	}
 
-	@GetMapping("/read/{id}")
+	@GetMapping("/posts/{id}")
 	public ResponseEntity<Post> readPostBySingle(@PathVariable Long id){
 		Post post = postService.readPostBySingle(id);
 
 		return ResponseEntity.ok(post);
 	}
 
-	@GetMapping("/readByViews")
+	@GetMapping("/views")
 	public ResponseEntity<Map<String, Object>> readByView(@RequestParam(defaultValue = "0") int page){
 		int size = 10;
 		Page<Post> postPage = postService.getPosts(page, size);
@@ -69,7 +69,7 @@ public class PostController {
 		return ResponseEntity.ok(response);
 	}
 
-	@DeleteMapping("/delete/{id}")
+	@DeleteMapping("/{id}")
 	public ResponseEntity<DataResponse<String>> deletePostBySingle(@PathVariable Long id) {
 		postService.deletePostBySingle(id);
 

--- a/backend/src/main/java/cotato/backend/domains/post/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostController.java
@@ -23,4 +23,11 @@ public class PostController {
 
 		return ResponseEntity.ok(DataResponse.ok());
 	}
+
+	@PostMapping("/single")
+	public ResponseEntity<DataResponse<Void>> savePostBySingle(@RequestBody PostDTO postDTO){
+		postService.savePostBySingle(postDTO);
+
+		return ResponseEntity.ok(DataResponse.ok());
+	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostController.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -65,6 +66,13 @@ public class PostController {
 		response.put("totalPages", postPage.getTotalPages());
 
 		return ResponseEntity.ok(response);
+	}
+
+	@DeleteMapping("/delete/{id}")
+	public ResponseEntity<DataResponse<String>> deletePostBySingle(@PathVariable Long id) {
+		postService.deletePostBySingle(id);
+
+		return ResponseEntity.ok(DataResponse.success("게시글이 성공적으로 삭제 되었습니다."));
 	}
 
 

--- a/backend/src/main/java/cotato/backend/domains/post/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostController.java
@@ -45,7 +45,7 @@ public class PostController {
 	}
 
 	@GetMapping("/{id}")
-	public ResponseEntity<Post> readPostBySingle(@PathVariable Long id){
+	public ResponseEntity<Post> readPostBySingle(@PathVariable Long id)  {
 		Post post = postService.readPostBySingle(id);
 
 		return ResponseEntity.ok(post);

--- a/backend/src/main/java/cotato/backend/domains/post/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostController.java
@@ -29,10 +29,12 @@ public class PostController {
 	private final PostService postService;
 
 	@PostMapping("/excel")
-	public ResponseEntity<DataResponse<Void>> savePostsByExcel(@RequestBody SavePostsByExcelRequest request) {
+	public ResponseEntity<DataResponse<Long>> savePostsByExcel(@RequestBody SavePostsByExcelRequest request) {
+		Long startTime = System.currentTimeMillis();
 		postService.saveEstatesByExcel(request.getPath());
-
-		return ResponseEntity.ok(DataResponse.ok());
+		Long endTime = System.currentTimeMillis();
+		Long elapsedTime = endTime - startTime;
+		return ResponseEntity.ok(DataResponse.from(elapsedTime));
 	}
 
 	@PostMapping("/single")

--- a/backend/src/main/java/cotato/backend/domains/post/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostController.java
@@ -50,7 +50,6 @@ public class PostController {
 
 		return ResponseEntity.ok(post);
 	}
-
 	@GetMapping("/views")
 	public ResponseEntity<Map<String, Object>> readByView(@RequestParam(defaultValue = "0") int page){
 		int size = 10;

--- a/backend/src/main/java/cotato/backend/domains/post/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostController.java
@@ -1,6 +1,8 @@
 package cotato.backend.domains.post;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,5 +31,12 @@ public class PostController {
 		postService.savePostBySingle(postDTO);
 
 		return ResponseEntity.ok(DataResponse.ok());
+	}
+
+	@GetMapping("/read/{id}")
+	public ResponseEntity<Post> readPostBySingle(@PathVariable Long id){
+		Post post = postService.readPostBySingle(id);
+
+		return ResponseEntity.ok(post);
 	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostController.java
@@ -42,7 +42,7 @@ public class PostController {
 		return ResponseEntity.ok(DataResponse.ok());
 	}
 
-	@GetMapping("/posts/{id}")
+	@GetMapping("/{id}")
 	public ResponseEntity<Post> readPostBySingle(@PathVariable Long id){
 		Post post = postService.readPostBySingle(id);
 
@@ -52,19 +52,8 @@ public class PostController {
 	@GetMapping("/views")
 	public ResponseEntity<Map<String, Object>> readByView(@RequestParam(defaultValue = "0") int page){
 		int size = 10;
-		Page<Post> postPage = postService.getPosts(page, size);
-		List<Map<String, Object>> filteredPosts = postPage.getContent().stream().map(post -> {
-			Map<String, Object> postMap = new HashMap<>();
-			postMap.put("id", post.getId());
-			postMap.put("title", post.getTitle());
-			postMap.put("name", post.getName());
-			return postMap;
-		}).collect(Collectors.toList());
-
-		Map<String, Object> response = new HashMap<>();
-		response.put("posts", filteredPosts); // 게시글 리스트
-		response.put("currentPage", postPage.getNumber()); // 현재 페이지
-		response.put("totalPages", postPage.getTotalPages());
+		Map<String, Object> response;
+		response = postService.getPosts(page, size);
 
 		return ResponseEntity.ok(response);
 	}

--- a/backend/src/main/java/cotato/backend/domains/post/PostDTO.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostDTO.java
@@ -1,24 +1,21 @@
 package cotato.backend.domains.post;
 
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
 public class PostDTO {
 
+	@NotBlank(message = "제목을 적어주세요")
 	private String title;
 
+	@NotBlank(message = "내용을 적어주세요")
 	private String content;
 
+	@NotBlank(message = "이름을 적어주세요")
 	private String name;
 
-	public String getTitle() {
-		return title;
-	}
 
-	public String getContent() {
-		return content;
-	}
-
-	public String getName() {
-		return name;
-	}
 
 
 }

--- a/backend/src/main/java/cotato/backend/domains/post/PostDTO.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostDTO.java
@@ -1,0 +1,24 @@
+package cotato.backend.domains.post;
+
+public class PostDTO {
+
+	private String title;
+
+	private String content;
+
+	private String name;
+
+	public String getTitle() {
+		return title;
+	}
+
+	public String getContent() {
+		return content;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+
+}

--- a/backend/src/main/java/cotato/backend/domains/post/PostRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostRepository.java
@@ -1,0 +1,9 @@
+package cotato.backend.domains.post;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+}

--- a/backend/src/main/java/cotato/backend/domains/post/PostRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostRepository.java
@@ -1,9 +1,11 @@
 package cotato.backend.domains.post;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
-
+	Page<Post> findAllByOrderByViewsDesc(Pageable pageable);
 }

--- a/backend/src/main/java/cotato/backend/domains/post/PostRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostRepository.java
@@ -1,11 +1,22 @@
 package cotato.backend.domains.post;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import jakarta.persistence.LockModeType;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 	Page<Post> findAllByOrderByViewsDesc(Pageable pageable);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT p FROM Post p WHERE p.id = :id")
+	Optional<Post> findByIdForUpdate(@Param("id") Long id);
 }

--- a/backend/src/main/java/cotato/backend/domains/post/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostService.java
@@ -6,6 +6,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,5 +58,10 @@ public class PostService {
 		post.setViews(post.getViews() + 1);
 
 		return post;
+	}
+
+	public Page<Post> getPosts(int page, int size) {
+		Pageable pageable = PageRequest.of(page, size);
+		return postRepository.findAllByOrderByViewsDesc(pageable);
 	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostService.java
@@ -56,7 +56,7 @@ public class PostService {
 	public Post readPostBySingle(Long id) {
 		Optional<Post> optionalPost = postRepository.findById(id);
 		Post post = optionalPost.get();
-		post.setViews(post.getViews() + 1);
+		post.update(1);
 
 		return post;
 	}

--- a/backend/src/main/java/cotato/backend/domains/post/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostService.java
@@ -57,7 +57,7 @@ public class PostService {
 	}
 
 	public Post readPostBySingle(Long id) {
-		Post post = postRepository.findById(id).orElseThrow(() -> ApiException.of(HttpStatus.NOT_FOUND, "해당 ID의 게시글을 핮을 수 없습니다", ""));
+		Post post = postRepository.findByIdForUpdate(id).orElseThrow(() -> ApiException.of(HttpStatus.NOT_FOUND, "해당 ID의 게시글을 핮을 수 없습니다", ""));
 		post.update(1);
 
 		return post;

--- a/backend/src/main/java/cotato/backend/domains/post/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostService.java
@@ -20,6 +20,8 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional
 public class PostService {
 
+	private final PostRepository postRepository;
+
 	// 로컬 파일 경로로부터 엑셀 파일을 읽어 Post 엔터티로 변환하고 저장
 	public void saveEstatesByExcel(String filePath) {
 		try {
@@ -38,5 +40,10 @@ public class PostService {
 			log.error("Failed to save estates by excel", e);
 			throw ApiException.from(INTERNAL_SERVER_ERROR);
 		}
+	}
+
+	public void savePostBySingle(PostDTO postDTO) {
+		Post post = new Post(postDTO.getTitle(), postDTO.getContent(), postDTO.getName());
+		postRepository.save(post);
 	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostService.java
@@ -35,6 +35,7 @@ public class PostService {
 					return new Post(title, content, name);
 				})
 				.collect(Collectors.toList());
+			postRepository.saveAll(posts);
 
 		} catch (Exception e) {
 			log.error("Failed to save estates by excel", e);

--- a/backend/src/main/java/cotato/backend/domains/post/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostService.java
@@ -27,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional
 public class PostService {
 
+
 	private final PostRepository postRepository;
 	private final BatchRepository batchRepository;
 

--- a/backend/src/main/java/cotato/backend/domains/post/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostService.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -64,4 +65,12 @@ public class PostService {
 		Pageable pageable = PageRequest.of(page, size);
 		return postRepository.findAllByOrderByViewsDesc(pageable);
 	}
+
+	public void deletePostBySingle(Long id) {
+		Post post = postRepository.findById(id)
+			.orElseThrow(() -> ApiException.of(HttpStatus.NOT_FOUND,"해당 ID의 게시글을 찾을 수 없습니다", ""));
+		postRepository.delete(post);
+
+	}
+
 }

--- a/backend/src/main/java/cotato/backend/domains/post/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostService.java
@@ -3,6 +3,7 @@ package cotato.backend.domains.post;
 import static cotato.backend.common.exception.ErrorCode.*;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -46,5 +47,13 @@ public class PostService {
 	public void savePostBySingle(PostDTO postDTO) {
 		Post post = new Post(postDTO.getTitle(), postDTO.getContent(), postDTO.getName());
 		postRepository.save(post);
+	}
+
+	public Post readPostBySingle(Long id) {
+		Optional<Post> optionalPost = postRepository.findById(id);
+		Post post = optionalPost.get();
+		post.setViews(post.getViews() + 1);
+
+		return post;
 	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostService.java
@@ -28,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 public class PostService {
 
 	private final PostRepository postRepository;
+	private final BatchRepository batchRepository;
 
 	// 로컬 파일 경로로부터 엑셀 파일을 읽어 Post 엔터티로 변환하고 저장
 	public void saveEstatesByExcel(String filePath) {
@@ -42,7 +43,7 @@ public class PostService {
 					return new Post(title, content, name);
 				})
 				.collect(Collectors.toList());
-			postRepository.saveAll(posts);
+			batchRepository.insert(posts);
 
 		} catch (Exception e) {
 			log.error("Failed to save estates by excel", e);

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,9 @@
 spring.application.name=backend
+spring.datasource.url=jdbc:mysql://localhost:3306/world?rewriteBatchedStatements=true
+spring.datasource.username=root
+spring.datasource.password=asd078!
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,9 +1,0 @@
-spring.application.name=backend
-spring.datasource.url=jdbc:mysql://localhost:3306/world?rewriteBatchedStatements=true
-spring.datasource.username=root
-spring.datasource.password=asd078!
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,0 +1,9 @@
+spring.application.name=backend
+spring.datasource.url=jdbc:mysql://localhost:3306/world?rewriteBatchedStatements=true
+spring.datasource.username=root
+spring.datasource.password=asd078!
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
[**Bulk Insert를 통한 최적화**]

**최적화 전** 
![최적화전](https://github.com/user-attachments/assets/d2dd3524-3da4-4346-938f-4583e48a39f4)

**최적화 후** 
![최적화후](https://github.com/user-attachments/assets/754a030a-381a-4030-9469-71babaccfad1)

약 70초가 걸리던 저장시간이 20초가량으로 줄었다. 

**[비관적 LOCK을 사용한 동시성 제어]** 
동시성을 처리하는 방법이 여러가지가 있지만, 게시물 조회같은 기능은 많은 충돌이 예상되므로 비관적 LOCK을 사용하여 해결하는 것이 적절하다. Jmeter를 사용하여 500명의 사용자가 동시에 1번 게시물을 조회하도록 했다.
조회수가 500인 것을 기대했지만 3분의 2 정도 날라간 것을 볼 수 있다.

**제어 전**
![동시성 제어 전](https://github.com/user-attachments/assets/2e35e739-661e-4604-842e-eb14d1b0aa89)


**제어 후**
![동시성 제어 후](https://github.com/user-attachments/assets/141effac-9960-4c03-b4ef-70c868b56df1)

