### PR TITLE
[윤찬호] 5차 과제 제출

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### properties ###
+*.properties

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     //swagger
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.5.0'
     testImplementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-api', version: '2.5.0'
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/cotato/backend/common/cache/CacheConfig.java
+++ b/backend/src/main/java/cotato/backend/common/cache/CacheConfig.java
@@ -1,0 +1,17 @@
+package cotato.backend.common.cache;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CacheConfig {
+
+	@Bean
+	public Map<Long, AtomicInteger> viewCounts() {
+		return new ConcurrentHashMap<>();
+	}
+}

--- a/backend/src/main/java/cotato/backend/common/dto/PageResponse.java
+++ b/backend/src/main/java/cotato/backend/common/dto/PageResponse.java
@@ -14,16 +14,16 @@ import lombok.NoArgsConstructor;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PageResponse<T> {
-	private List<T> items;
+	private List<T> content;
 	private int currentPage;
 	private int totalPages;
-	private long totalItems;
+	private long totalElements;
 
 	private PageResponse(List<T> content, int number, int totalPages, long totalElements) {
-		this.items = content;
+		this.content = content;
 		this.currentPage = number;
 		this.totalPages = totalPages;
-		this.totalItems = totalElements;
+		this.totalElements = totalElements;
 	}
 
 	public static <T> PageResponse<T> from(Page<T> page) {

--- a/backend/src/main/java/cotato/backend/common/dto/PageResponse.java
+++ b/backend/src/main/java/cotato/backend/common/dto/PageResponse.java
@@ -1,0 +1,37 @@
+package cotato.backend.common.dto;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PageResponse<T> {
+	private List<T> items;
+	private int currentPage;
+	private int totalPages;
+	private long totalItems;
+
+	private PageResponse(List<T> content, int number, int totalPages, long totalElements) {
+		this.items = content;
+		this.currentPage = number;
+		this.totalPages = totalPages;
+		this.totalItems = totalElements;
+	}
+
+	public static <T> PageResponse<T> from(Page<T> page) {
+		return new PageResponse<>(
+			page.getContent(),
+			page.getNumber(),
+			page.getTotalPages(),
+			page.getTotalElements()
+		);
+	}
+}

--- a/backend/src/main/java/cotato/backend/common/dummyData/DummyDataInitializer.java
+++ b/backend/src/main/java/cotato/backend/common/dummyData/DummyDataInitializer.java
@@ -1,0 +1,52 @@
+package cotato.backend.common.dummyData;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.annotation.Transactional;
+
+import cotato.backend.domains.post.entity.Post;
+import cotato.backend.domains.post.repository.PostJDBCRepository;
+import cotato.backend.domains.post.repository.PostRepository;
+import lombok.extern.slf4j.Slf4j;
+
+@Configuration
+@Slf4j
+public class DummyDataInitializer {
+
+	private final int BATCH_SIZE = 5000;
+
+	@Bean
+	CommandLineRunner initData(PostRepository postRepository, PostJDBCRepository postJDBCRepository) {
+		// postRepository가 비어있으면 데이터를 초기화한다.
+		return args -> {
+			if (postRepository.count() == 0) {
+				initializeData(postJDBCRepository);
+			}
+		};
+	}
+
+	@Transactional
+	public void initializeData(PostJDBCRepository postJDBCRepository) {
+		List<Post> posts = new ArrayList<>();
+		for (int i = 1; i <= 500000; i++) {
+			// Post 엔터티를 생성하고 저장
+			Post post = new Post("title" + i, "content" + i, "name" + i);
+			posts.add(post);
+
+			// 배치 크기만큼 모이면 저장
+			if (i % BATCH_SIZE == 0) {
+				postJDBCRepository.saveAll(posts); // JDBC를 통한 저장, 영속성 컨텍스트에 데이터가 쌇이는 것을 방지.
+				posts.clear(); // 리스트 비우기, out of memory 방지
+			}
+		}
+		// 남아있는 데이터 저장
+		if (!posts.isEmpty()) {
+			postJDBCRepository.saveAll(posts);
+			posts.clear();
+		}
+	}
+}

--- a/backend/src/main/java/cotato/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/cotato/backend/common/exception/ErrorCode.java
@@ -9,12 +9,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-	//400
+	//Common
 	BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.", "COMMON-001"),
 	INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 잘 못 되었습니다.", "COMMON-002"),
-
-	//500
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에서 에러가 발생하였습니다.", "COMMON-002"),
+
+	//Post
+	POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 POST를 찾을 수 없습니다.", "POST-001"),
 	;
 
 	private final HttpStatus httpStatus;

--- a/backend/src/main/java/cotato/backend/common/redis/RedisCacheConfig.java
+++ b/backend/src/main/java/cotato/backend/common/redis/RedisCacheConfig.java
@@ -1,0 +1,42 @@
+package cotato.backend.common.redis;
+
+import java.time.Duration;
+
+import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching // Spring Boot의 캐싱 설정을 활성화
+public class RedisCacheConfig {
+
+	// 기본 캐시 전략
+	@Bean
+	public RedisCacheConfiguration redisCacheConfiguration() {
+		return RedisCacheConfiguration.defaultCacheConfig()
+			.entryTtl(Duration.ofSeconds(60))
+			.disableCachingNullValues()
+			.serializeKeysWith(
+				RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
+			)
+			.serializeValuesWith(
+				RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())
+			);
+	}
+
+	// 커스텀 캐시 전략
+	@Bean
+	public RedisCacheManagerBuilderCustomizer redisCacheManagerBuilderCustomizer() {
+		return (builder) -> builder
+			.withCacheConfiguration("shortTermCache",
+				RedisCacheConfiguration.defaultCacheConfig()
+					.entryTtl(Duration.ofMinutes(1)) // cache1에 TTL 1분
+					.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+					.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())));
+	}
+}

--- a/backend/src/main/java/cotato/backend/common/redis/RedisConfig.java
+++ b/backend/src/main/java/cotato/backend/common/redis/RedisConfig.java
@@ -1,0 +1,22 @@
+package cotato.backend.common.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+
+	@Value("${spring.data.redis.host}")
+	private String host;
+
+	@Value("${spring.data.redis.port}")
+	private int port;
+
+	@Bean
+	public LettuceConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+	}
+}

--- a/backend/src/main/java/cotato/backend/common/scheduling/SchedulerConfig.java
+++ b/backend/src/main/java/cotato/backend/common/scheduling/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package cotato.backend.common.scheduling;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/backend/src/main/java/cotato/backend/common/scheduling/SchedulerTasks.java
+++ b/backend/src/main/java/cotato/backend/common/scheduling/SchedulerTasks.java
@@ -1,0 +1,33 @@
+package cotato.backend.common.scheduling;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import cotato.backend.domains.post.entity.Post;
+import cotato.backend.domains.post.service.PostService;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SchedulerTasks {
+
+	private final Map<Long, AtomicInteger> viewCounts;
+	private final PostService postService;
+
+	// 조회수 증가를 DB에 반영
+	@Scheduled(fixedRate = 10000) // 매 1분마다 캐시를 DB에 반영
+	@Transactional
+	public void persistViewCounts() {
+		viewCounts.forEach((postId, count) -> {
+			Post post = postService.findById(postId);
+
+			post.setViews(post.getViews() + count.get());
+
+			count.set(0); // 캐시 초기화
+		});
+	}
+}

--- a/backend/src/main/java/cotato/backend/domains/post/Post.java
+++ b/backend/src/main/java/cotato/backend/domains/post/Post.java
@@ -1,6 +1,12 @@
 package cotato.backend.domains.post;
 
+import static jakarta.persistence.GenerationType.*;
+
+import cotato.backend.domains.post.dto.request.SavePostRequest;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,4 +16,39 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post {
 
+	@Id
+	@Column(name = "post_id")
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private String title;
+
+	@Column(nullable = false)
+	private String content;
+
+	@Column(nullable = false)
+	private String name;
+
+	@Column(nullable = false)
+	private Long views;
+
+	public Post(
+		String title,
+		String content,
+		String name
+	) {
+		this.title = title;
+		this.content = content;
+		this.name = name;
+		this.views = 0L;
+	}
+
+	public static Post of(SavePostRequest savePostRequest) {
+		return new Post(
+			savePostRequest.getTitle(),
+			savePostRequest.getContent(),
+			savePostRequest.getName()
+		);
+	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/Post.java
+++ b/backend/src/main/java/cotato/backend/domains/post/Post.java
@@ -44,7 +44,7 @@ public class Post {
 		this.views = 0L;
 	}
 
-	public static Post of(SavePostRequest savePostRequest) {
+	public static Post from(SavePostRequest savePostRequest) {
 		return new Post(
 			savePostRequest.getTitle(),
 			savePostRequest.getContent(),

--- a/backend/src/main/java/cotato/backend/domains/post/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostController.java
@@ -1,9 +1,11 @@
 package cotato.backend.domains.post;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import cotato.backend.common.dto.DataResponse;
@@ -28,6 +30,13 @@ public class PostController {
 	@PostMapping
 	public ResponseEntity<DataResponse<Void>> savePost(@RequestBody SavePostRequest request) {
 		postService.save(request);
+
+		return ResponseEntity.ok(DataResponse.ok());
+	}
+
+	@GetMapping("/{postId}")
+	public ResponseEntity<DataResponse<Void>> findPostById(@RequestParam Long postId) {
+		postService.findPostById(postId);
 
 		return ResponseEntity.ok(DataResponse.ok());
 	}

--- a/backend/src/main/java/cotato/backend/domains/post/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import cotato.backend.common.dto.DataResponse;
+import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.dto.request.SavePostsByExcelRequest;
 import lombok.RequiredArgsConstructor;
 
@@ -20,6 +21,13 @@ public class PostController {
 	@PostMapping("/excel")
 	public ResponseEntity<DataResponse<Void>> savePostsByExcel(@RequestBody SavePostsByExcelRequest request) {
 		postService.saveEstatesByExcel(request.getPath());
+
+		return ResponseEntity.ok(DataResponse.ok());
+	}
+
+	@PostMapping
+	public ResponseEntity<DataResponse<Void>> savePost(@RequestBody SavePostRequest request) {
+		postService.save(request);
 
 		return ResponseEntity.ok(DataResponse.ok());
 	}

--- a/backend/src/main/java/cotato/backend/domains/post/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostService.java
@@ -10,7 +10,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import cotato.backend.common.excel.ExcelUtils;
 import cotato.backend.common.exception.ApiException;
+import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.repository.PostJDBCRepository;
+import cotato.backend.domains.post.repository.PostRepository;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 public class PostService {
 
 	private final PostJDBCRepository postJDBCRepository;
+	private final PostRepository postRepository;
 
 	// 로컬 파일 경로로부터 엑셀 파일을 읽어 Post 엔터티로 변환하고 저장
 	public void saveEstatesByExcel(String filePath) {
@@ -43,5 +46,12 @@ public class PostService {
 			log.error("Failed to save estates by excel", e);
 			throw ApiException.from(INTERNAL_SERVER_ERROR);
 		}
+	}
+
+	// 글 저장
+	public void save(SavePostRequest request) {
+		Post post = Post.from(request);
+
+		postRepository.save(post);
 	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import cotato.backend.common.excel.ExcelUtils;
 import cotato.backend.common.exception.ApiException;
+import cotato.backend.domains.post.repository.PostJDBCRepository;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +20,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 @Transactional
 public class PostService {
+
+	private final PostJDBCRepository postJDBCRepository;
 
 	// 로컬 파일 경로로부터 엑셀 파일을 읽어 Post 엔터티로 변환하고 저장
 	public void saveEstatesByExcel(String filePath) {
@@ -34,6 +37,8 @@ public class PostService {
 				})
 				.collect(Collectors.toList());
 
+			// Post 엔터티를 저장
+			postJDBCRepository.saveAll(posts);
 		} catch (Exception e) {
 			log.error("Failed to save estates by excel", e);
 			throw ApiException.from(INTERNAL_SERVER_ERROR);

--- a/backend/src/main/java/cotato/backend/domains/post/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/PostService.java
@@ -54,4 +54,9 @@ public class PostService {
 
 		postRepository.save(post);
 	}
+
+	public void findPostById(Long postId) {
+		postRepository.findById(postId)
+			.orElseThrow(() -> ApiException.from(POST_NOT_FOUND));
+	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
@@ -17,6 +17,7 @@ import cotato.backend.domains.post.dto.request.SavePostsByExcelRequest;
 import cotato.backend.domains.post.dto.response.FindPostByIdResponse;
 import cotato.backend.domains.post.dto.response.FindPostsByPopularResponse;
 import cotato.backend.domains.post.service.PostService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -27,14 +28,14 @@ public class PostController {
 	private final PostService postService;
 
 	@PostMapping("/excel")
-	public ResponseEntity<DataResponse<Void>> savePostsByExcel(@RequestBody SavePostsByExcelRequest request) {
+	public ResponseEntity<DataResponse<Void>> savePostsByExcel(@RequestBody @Valid SavePostsByExcelRequest request) {
 		postService.saveEstatesByExcel(request.getPath());
 
 		return ResponseEntity.ok(DataResponse.ok());
 	}
 
 	@PostMapping
-	public ResponseEntity<DataResponse<Void>> savePost(@RequestBody SavePostRequest request) {
+	public ResponseEntity<DataResponse<Void>> savePost(@RequestBody @Valid SavePostRequest request) {
 		postService.save(request);
 
 		return ResponseEntity.ok(DataResponse.ok());

--- a/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
@@ -1,6 +1,7 @@
-package cotato.backend.domains.post;
+package cotato.backend.domains.post.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import cotato.backend.common.dto.DataResponse;
+import cotato.backend.domains.post.service.PostService;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.dto.request.SavePostsByExcelRequest;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +39,13 @@ public class PostController {
 	@GetMapping("/{postId}")
 	public ResponseEntity<DataResponse<Void>> findPostById(@RequestParam Long postId) {
 		postService.findPostById(postId);
+
+		return ResponseEntity.ok(DataResponse.ok());
+	}
+
+	@DeleteMapping("/{postId}")
+	public ResponseEntity<DataResponse<Void>> deletePostById(@RequestParam Long postId) {
+		postService.deletePostById(postId);
 
 		return ResponseEntity.ok(DataResponse.ok());
 	}

--- a/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
@@ -1,5 +1,6 @@
 package cotato.backend.domains.post.controller;
 
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -7,12 +8,14 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import cotato.backend.common.dto.DataResponse;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.dto.request.SavePostsByExcelRequest;
 import cotato.backend.domains.post.dto.response.FindPostByIdResponse;
+import cotato.backend.domains.post.dto.response.FindPostsByPopularResponse;
 import cotato.backend.domains.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 
@@ -49,5 +52,15 @@ public class PostController {
 		postService.deletePostById(postId);
 
 		return ResponseEntity.ok(DataResponse.ok());
+	}
+
+	@GetMapping
+	public ResponseEntity<DataResponse<Page<FindPostsByPopularResponse>>> findPostsByPopular(
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size
+	) {
+		Page<FindPostsByPopularResponse> responses = postService.findPostsByPopular(page, size);
+
+		return ResponseEntity.ok(DataResponse.from(responses));
 	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
@@ -3,16 +3,17 @@ package cotato.backend.domains.post.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import cotato.backend.common.dto.DataResponse;
-import cotato.backend.domains.post.service.PostService;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.dto.request.SavePostsByExcelRequest;
+import cotato.backend.domains.post.dto.response.FindPostByIdResponse;
+import cotato.backend.domains.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -37,14 +38,14 @@ public class PostController {
 	}
 
 	@GetMapping("/{postId}")
-	public ResponseEntity<DataResponse<Void>> findPostById(@RequestParam Long postId) {
-		postService.findPostById(postId);
+	public ResponseEntity<DataResponse<FindPostByIdResponse>> findPostById(@PathVariable Long postId) {
+		FindPostByIdResponse response = postService.findPostById(postId);
 
-		return ResponseEntity.ok(DataResponse.ok());
+		return ResponseEntity.ok(DataResponse.from(response));
 	}
 
 	@DeleteMapping("/{postId}")
-	public ResponseEntity<DataResponse<Void>> deletePostById(@RequestParam Long postId) {
+	public ResponseEntity<DataResponse<Void>> deletePostById(@PathVariable Long postId) {
 		postService.deletePostById(postId);
 
 		return ResponseEntity.ok(DataResponse.ok());

--- a/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
@@ -1,6 +1,5 @@
 package cotato.backend.domains.post.controller;
 
-import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import cotato.backend.common.dto.DataResponse;
+import cotato.backend.common.dto.PageResponse;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.dto.request.SavePostsByExcelRequest;
 import cotato.backend.domains.post.dto.response.FindPostByIdResponse;
@@ -56,11 +56,11 @@ public class PostController {
 	}
 
 	@GetMapping
-	public ResponseEntity<DataResponse<Page<FindPostsByPopularResponse>>> findPostsByPopular(
+	public ResponseEntity<DataResponse<PageResponse<FindPostsByPopularResponse>>> findPostsByPopular(
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "10") int size
 	) {
-		Page<FindPostsByPopularResponse> responses = postService.findPostsByPopular(page, size);
+		PageResponse<FindPostsByPopularResponse> responses = postService.findPostsByPopular(page, size);
 
 		return ResponseEntity.ok(DataResponse.from(responses));
 	}

--- a/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
+++ b/backend/src/main/java/cotato/backend/domains/post/controller/PostController.java
@@ -43,7 +43,7 @@ public class PostController {
 
 	@GetMapping("/{postId}")
 	public ResponseEntity<DataResponse<FindPostByIdResponse>> findPostById(@PathVariable Long postId) {
-		FindPostByIdResponse response = postService.findPostById(postId);
+		FindPostByIdResponse response = postService.findPostDtoByIdAndIncreaseView(postId);
 
 		return ResponseEntity.ok(DataResponse.from(response));
 	}

--- a/backend/src/main/java/cotato/backend/domains/post/dto/request/SavePostRequest.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/request/SavePostRequest.java
@@ -1,11 +1,17 @@
 package cotato.backend.domains.post.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 @Data
 public class SavePostRequest {
 
+	@NotBlank(message = "제목을 입력해주세요.")
 	private String title;
+
+	@NotBlank(message = "내용을 입력해주세요.")
 	private String content;
+
+	@NotBlank(message = "작성자를 입력해주세요.")
 	private String name;
 }

--- a/backend/src/main/java/cotato/backend/domains/post/dto/request/SavePostRequest.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/request/SavePostRequest.java
@@ -1,0 +1,11 @@
+package cotato.backend.domains.post.dto.request;
+
+import lombok.Data;
+
+@Data
+public class SavePostRequest {
+
+	private String title;
+	private String content;
+	private String name;
+}

--- a/backend/src/main/java/cotato/backend/domains/post/dto/request/SavePostsByExcelRequest.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/request/SavePostsByExcelRequest.java
@@ -5,7 +5,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SavePostsByExcelRequest {
 
 	private String path;

--- a/backend/src/main/java/cotato/backend/domains/post/dto/request/SavePostsByExcelRequest.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/request/SavePostsByExcelRequest.java
@@ -1,5 +1,6 @@
 package cotato.backend.domains.post.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -7,5 +8,6 @@ import lombok.NoArgsConstructor;
 @Data
 public class SavePostsByExcelRequest {
 
+	@NotBlank(message = "파일 경로를 입력해주세요.")
 	private String path;
 }

--- a/backend/src/main/java/cotato/backend/domains/post/dto/response/FindPostByIdResponse.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/response/FindPostByIdResponse.java
@@ -1,0 +1,25 @@
+package cotato.backend.domains.post.dto.response;
+
+import cotato.backend.domains.post.entity.Post;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class FindPostByIdResponse {
+
+	private String title;
+	private String content;
+	private String name;
+	private Long views;
+
+	public static FindPostByIdResponse from(Post post) {
+		return new FindPostByIdResponse(
+			post.getTitle(),
+			post.getContent(),
+			post.getName(),
+			post.getViews()
+		);
+	}
+}

--- a/backend/src/main/java/cotato/backend/domains/post/dto/response/FindPostsByPopularResponse.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/response/FindPostsByPopularResponse.java
@@ -1,0 +1,27 @@
+package cotato.backend.domains.post.dto.response;
+
+import cotato.backend.domains.post.entity.Post;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class FindPostsByPopularResponse {
+
+	private String postId;
+	private String title;
+	private String content;
+	private String name;
+	private Long views;
+
+	public static FindPostsByPopularResponse from(Post post) {
+		return new FindPostsByPopularResponse(
+			post.getId().toString(),
+			post.getTitle(),
+			post.getContent(),
+			post.getName(),
+			post.getViews()
+		);
+	}
+}

--- a/backend/src/main/java/cotato/backend/domains/post/dto/response/FindPostsByPopularResponse.java
+++ b/backend/src/main/java/cotato/backend/domains/post/dto/response/FindPostsByPopularResponse.java
@@ -4,9 +4,11 @@ import cotato.backend.domains.post.entity.Post;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FindPostsByPopularResponse {
 
 	private String postId;

--- a/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
+++ b/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
@@ -1,4 +1,4 @@
-package cotato.backend.domains.post;
+package cotato.backend.domains.post.entity;
 
 import static jakarta.persistence.GenerationType.*;
 

--- a/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
+++ b/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
@@ -51,4 +51,8 @@ public class Post {
 			savePostRequest.getName()
 		);
 	}
+
+	public void increaseViews() {
+		this.views++;
+	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
+++ b/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
@@ -31,6 +32,7 @@ public class Post {
 	private String name;
 
 	@Column(nullable = false)
+	@Setter
 	private Long views;
 
 	public Post(
@@ -50,9 +52,5 @@ public class Post {
 			savePostRequest.getContent(),
 			savePostRequest.getName()
 		);
-	}
-
-	public void increaseViews() {
-		this.views++;
 	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
+++ b/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
@@ -7,7 +7,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
-import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -34,9 +33,6 @@ public class Post {
 	@Column(nullable = false)
 	private Long views;
 
-	@Version
-	private Long version;
-
 	public Post(
 		String title,
 		String content,
@@ -46,7 +42,6 @@ public class Post {
 		this.content = content;
 		this.name = name;
 		this.views = 0L;
-		this.version = 0L;
 	}
 
 	public static Post from(SavePostRequest savePostRequest) {

--- a/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
+++ b/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -33,6 +34,9 @@ public class Post {
 	@Column(nullable = false)
 	private Long views;
 
+	@Version
+	private Long version;
+
 	public Post(
 		String title,
 		String content,
@@ -42,6 +46,7 @@ public class Post {
 		this.content = content;
 		this.name = name;
 		this.views = 0L;
+		this.version = 0L;
 	}
 
 	public static Post from(SavePostRequest savePostRequest) {

--- a/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
+++ b/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
@@ -2,6 +2,8 @@ package cotato.backend.domains.post.entity;
 
 import static jakarta.persistence.GenerationType.*;
 
+import org.hibernate.annotations.ColumnDefault;
+
 import cotato.backend.domains.post.dto.request.SavePostRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -38,7 +40,8 @@ public class Post {
 
 	@Column(nullable = false)
 	@Setter
-	private Long views;
+	@ColumnDefault("0")
+	private Long views = 0L;
 
 	public Post(
 		String title,
@@ -48,7 +51,6 @@ public class Post {
 		this.title = title;
 		this.content = content;
 		this.name = name;
-		this.views = 0L;
 	}
 
 	public static Post from(SavePostRequest savePostRequest) {

--- a/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
+++ b/backend/src/main/java/cotato/backend/domains/post/entity/Post.java
@@ -7,6 +7,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,6 +16,9 @@ import lombok.Setter;
 
 @Entity
 @Getter
+@Table(name = "post", indexes = {
+	@Index(name = "idx_views", columnList = "views")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post {
 

--- a/backend/src/main/java/cotato/backend/domains/post/repository/PostJDBCRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/repository/PostJDBCRepository.java
@@ -18,7 +18,7 @@ public class PostJDBCRepository {
 
 	@Transactional
 	public void saveAll(List<Post> posts) {
-		String sql = "INSERT INTO post (title, content, name) " +
+		String sql = "INSERT INTO post (title, content, name, views) " +
 			"VALUES (?, ?, ?, ?)";
 
 		jdbcTemplate.batchUpdate(sql,
@@ -28,6 +28,7 @@ public class PostJDBCRepository {
 				ps.setString(1, post.getTitle());
 				ps.setString(2, post.getContent());
 				ps.setString(3, post.getName());
+				ps.setLong(4, post.getViews());
 			});
 	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/repository/PostJDBCRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/repository/PostJDBCRepository.java
@@ -1,0 +1,33 @@
+package cotato.backend.domains.post.repository;
+
+import java.sql.PreparedStatement;
+import java.util.List;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import cotato.backend.domains.post.Post;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class PostJDBCRepository {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	@Transactional
+	public void saveAll(List<Post> posts) {
+		String sql = "INSERT INTO post (title, content, name) " +
+			"VALUES (?, ?, ?, ?)";
+
+		jdbcTemplate.batchUpdate(sql,
+			posts,
+			posts.size(),
+			(PreparedStatement ps, Post post) -> {
+				ps.setString(1, post.getTitle());
+				ps.setString(2, post.getContent());
+				ps.setString(3, post.getName());
+			});
+	}
+}

--- a/backend/src/main/java/cotato/backend/domains/post/repository/PostJDBCRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/repository/PostJDBCRepository.java
@@ -6,7 +6,7 @@ import java.util.List;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-import cotato.backend.domains.post.Post;
+import cotato.backend.domains.post.entity.Post;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 

--- a/backend/src/main/java/cotato/backend/domains/post/repository/PostJDBCRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/repository/PostJDBCRepository.java
@@ -18,8 +18,8 @@ public class PostJDBCRepository {
 
 	@Transactional
 	public void saveAll(List<Post> posts) {
-		String sql = "INSERT INTO post (title, content, name, views, version) " +
-			"VALUES (?, ?, ?, ?, ?)";
+		String sql = "INSERT INTO post (title, content, name, views) " +
+			"VALUES (?, ?, ?, ?)";
 
 		jdbcTemplate.batchUpdate(sql,
 			posts,
@@ -29,7 +29,6 @@ public class PostJDBCRepository {
 				ps.setString(2, post.getContent());
 				ps.setString(3, post.getName());
 				ps.setLong(4, post.getViews());
-				ps.setLong(5, post.getVersion());
 			});
 	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/repository/PostJDBCRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/repository/PostJDBCRepository.java
@@ -18,8 +18,8 @@ public class PostJDBCRepository {
 
 	@Transactional
 	public void saveAll(List<Post> posts) {
-		String sql = "INSERT INTO post (title, content, name, views) " +
-			"VALUES (?, ?, ?, ?)";
+		String sql = "INSERT INTO post (title, content, name, views, version) " +
+			"VALUES (?, ?, ?, ?, ?)";
 
 		jdbcTemplate.batchUpdate(sql,
 			posts,
@@ -29,6 +29,7 @@ public class PostJDBCRepository {
 				ps.setString(2, post.getContent());
 				ps.setString(3, post.getName());
 				ps.setLong(4, post.getViews());
+				ps.setLong(5, post.getVersion());
 			});
 	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/repository/PostRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/repository/PostRepository.java
@@ -2,7 +2,7 @@ package cotato.backend.domains.post.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import cotato.backend.domains.post.Post;
+import cotato.backend.domains.post.entity.Post;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 }

--- a/backend/src/main/java/cotato/backend/domains/post/repository/PostRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/repository/PostRepository.java
@@ -1,8 +1,12 @@
 package cotato.backend.domains.post.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import cotato.backend.domains.post.entity.Post;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+	Page<Post> findAllByOrderByViewsDesc(Pageable pageable);
 }

--- a/backend/src/main/java/cotato/backend/domains/post/repository/PostRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/repository/PostRepository.java
@@ -1,0 +1,8 @@
+package cotato.backend.domains.post.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import cotato.backend.domains.post.Post;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/backend/src/main/java/cotato/backend/domains/post/repository/PostRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/repository/PostRepository.java
@@ -1,12 +1,20 @@
 package cotato.backend.domains.post.repository;
 
+import static jakarta.persistence.LockModeType.*;
+
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
 import cotato.backend.domains.post.entity.Post;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
 	Page<Post> findAllByOrderByViewsDesc(Pageable pageable);
+
+	@Lock(PESSIMISTIC_WRITE)
+	Optional<Post> findById(Long id);
 }

--- a/backend/src/main/java/cotato/backend/domains/post/repository/PostRepository.java
+++ b/backend/src/main/java/cotato/backend/domains/post/repository/PostRepository.java
@@ -1,20 +1,12 @@
 package cotato.backend.domains.post.repository;
 
-import static jakarta.persistence.LockModeType.*;
-
-import java.util.Optional;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 
 import cotato.backend.domains.post.entity.Post;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
 	Page<Post> findAllByOrderByViewsDesc(Pageable pageable);
-
-	@Lock(PESSIMISTIC_WRITE)
-	Optional<Post> findById(Long id);
 }

--- a/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import cotato.backend.common.excel.ExcelUtils;
 import cotato.backend.common.exception.ApiException;
+import cotato.backend.domains.post.dto.response.FindPostByIdResponse;
 import cotato.backend.domains.post.entity.Post;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.repository.PostJDBCRepository;
@@ -57,9 +58,11 @@ public class PostService {
 	}
 
 	// 글 조회
-	public void findPostById(Long postId) {
-		postRepository.findById(postId)
+	public FindPostByIdResponse findPostById(Long postId) {
+		Post post = postRepository.findById(postId)
 			.orElseThrow(() -> ApiException.from(POST_NOT_FOUND));
+
+		return FindPostByIdResponse.from(post);
 	}
 
 	// 글 삭제

--- a/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
@@ -76,4 +76,13 @@ public class PostService {
 	public void deletePostById(Long postId) {
 		postRepository.deleteById(postId);
 	}
+
+	// 글목록 인기순 조회
+	public Page<FindPostsByPopularResponse> findPostsByPopular(int page, int size) {
+		PageRequest pageRequest = PageRequest.of(page, size);
+
+		Page<Post> posts = postRepository.findAllByOrderByViewsDesc(pageRequest);
+
+		return posts.map(FindPostsByPopularResponse::from);
+	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
@@ -22,13 +22,14 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-@Transactional
+@Transactional(readOnly = true)
 public class PostService {
 
 	private final PostJDBCRepository postJDBCRepository;
 	private final PostRepository postRepository;
 
 	// 로컬 파일 경로로부터 엑셀 파일을 읽어 Post 엔터티로 변환하고 저장
+	@Transactional
 	public void saveEstatesByExcel(String filePath) {
 		try {
 			// 엑셀 파일을 읽어 데이터 프레임 형태로 변환
@@ -51,6 +52,7 @@ public class PostService {
 	}
 
 	// 글 저장
+	@Transactional
 	public void save(SavePostRequest request) {
 		Post post = Post.from(request);
 
@@ -58,14 +60,19 @@ public class PostService {
 	}
 
 	// 글 조회
+	@Transactional
 	public FindPostByIdResponse findPostById(Long postId) {
 		Post post = postRepository.findById(postId)
 			.orElseThrow(() -> ApiException.from(POST_NOT_FOUND));
+
+		// 조회수 증가
+		post.increaseViews();
 
 		return FindPostByIdResponse.from(post);
 	}
 
 	// 글 삭제
+	@Transactional
 	public void deletePostById(Long postId) {
 		postRepository.deleteById(postId);
 	}

--- a/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
@@ -1,4 +1,4 @@
-package cotato.backend.domains.post;
+package cotato.backend.domains.post.service;
 
 import static cotato.backend.common.exception.ErrorCode.*;
 
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import cotato.backend.common.excel.ExcelUtils;
 import cotato.backend.common.exception.ApiException;
+import cotato.backend.domains.post.entity.Post;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.repository.PostJDBCRepository;
 import cotato.backend.domains.post.repository.PostRepository;
@@ -55,8 +56,14 @@ public class PostService {
 		postRepository.save(post);
 	}
 
+	// 글 조회
 	public void findPostById(Long postId) {
 		postRepository.findById(postId)
 			.orElseThrow(() -> ApiException.from(POST_NOT_FOUND));
+	}
+
+	// 글 삭제
+	public void deletePostById(Long postId) {
+		postRepository.deleteById(postId);
 	}
 }

--- a/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
@@ -7,16 +7,15 @@ import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import cotato.backend.common.excel.ExcelUtils;
 import cotato.backend.common.exception.ApiException;
+import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.dto.response.FindPostByIdResponse;
 import cotato.backend.domains.post.dto.response.FindPostsByPopularResponse;
 import cotato.backend.domains.post.entity.Post;
-import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.repository.PostJDBCRepository;
 import cotato.backend.domains.post.repository.PostRepository;
 import lombok.AccessLevel;
@@ -31,8 +30,6 @@ public class PostService {
 
 	private final PostJDBCRepository postJDBCRepository;
 	private final PostRepository postRepository;
-
-	private static final int MAX_RETRIES = 3;
 
 	// 로컬 파일 경로로부터 엑셀 파일을 읽어 Post 엔터티로 변환하고 저장
 	@Transactional
@@ -73,32 +70,9 @@ public class PostService {
 			.orElseThrow(() -> ApiException.from(POST_NOT_FOUND));
 
 		// 조회수 증가
-		safeIncreaseViews(post);
+		post.increaseViews();
 
 		return FindPostByIdResponse.from(post);
-	}
-
-	private void safeIncreaseViews(Post post) {
-		int attempt = 0;
-		boolean success = false;
-
-		while (attempt < MAX_RETRIES && !success) {
-			try {
-				attempt++;
-
-				// 조회수 증가
-				post.increaseViews();
-
-				postRepository.save(post);
-				success = true; // 저장 성공 시 반복문 종료
-			} catch (ObjectOptimisticLockingFailureException e) {
-				if (attempt >= MAX_RETRIES) {
-					throw ApiException.from(INTERNAL_SERVER_ERROR);
-				}
-				// 로그 출력
-				System.out.println("Optimistic lock exception on attempt " + attempt + ". Retrying...");
-			}
-		}
 	}
 
 	// 글 삭제

--- a/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
@@ -102,6 +102,7 @@ public class PostService {
 	}
 
 	// 글 조회
+	@Cacheable(cacheNames = "shortTermCache", key = "'posts:postId:' + #postId")
 	public Post findById(Long postId) {
 		return postRepository.findById(postId)
 			.orElseThrow(() -> ApiException.from(POST_NOT_FOUND));

--- a/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
@@ -5,12 +5,16 @@ import static cotato.backend.common.exception.ErrorCode.*;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import cotato.backend.common.excel.ExcelUtils;
 import cotato.backend.common.exception.ApiException;
 import cotato.backend.domains.post.dto.response.FindPostByIdResponse;
+import cotato.backend.domains.post.dto.response.FindPostsByPopularResponse;
 import cotato.backend.domains.post.entity.Post;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
 import cotato.backend.domains.post.repository.PostJDBCRepository;
@@ -27,6 +31,8 @@ public class PostService {
 
 	private final PostJDBCRepository postJDBCRepository;
 	private final PostRepository postRepository;
+
+	private static final int MAX_RETRIES = 3;
 
 	// 로컬 파일 경로로부터 엑셀 파일을 읽어 Post 엔터티로 변환하고 저장
 	@Transactional
@@ -59,6 +65,7 @@ public class PostService {
 		postRepository.save(post);
 	}
 
+
 	// 글 조회
 	@Transactional
 	public FindPostByIdResponse findPostById(Long postId) {
@@ -66,9 +73,32 @@ public class PostService {
 			.orElseThrow(() -> ApiException.from(POST_NOT_FOUND));
 
 		// 조회수 증가
-		post.increaseViews();
+		safeIncreaseViews(post);
 
 		return FindPostByIdResponse.from(post);
+	}
+
+	private void safeIncreaseViews(Post post) {
+		int attempt = 0;
+		boolean success = false;
+
+		while (attempt < MAX_RETRIES && !success) {
+			try {
+				attempt++;
+
+				// 조회수 증가
+				post.increaseViews();
+
+				postRepository.save(post);
+				success = true; // 저장 성공 시 반복문 종료
+			} catch (ObjectOptimisticLockingFailureException e) {
+				if (attempt >= MAX_RETRIES) {
+					throw ApiException.from(INTERNAL_SERVER_ERROR);
+				}
+				// 로그 출력
+				System.out.println("Optimistic lock exception on attempt " + attempt + ". Retrying...");
+			}
+		}
 	}
 
 	// 글 삭제

--- a/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
@@ -7,11 +7,13 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import cotato.backend.common.dto.PageResponse;
 import cotato.backend.common.excel.ExcelUtils;
 import cotato.backend.common.exception.ApiException;
 import cotato.backend.domains.post.dto.request.SavePostRequest;
@@ -90,12 +92,13 @@ public class PostService {
 	}
 
 	// 글목록 인기순 조회
-	public Page<FindPostsByPopularResponse> findPostsByPopular(int page, int size) {
+	@Cacheable(cacheNames = "shortTermCache", key = "'posts:page:' + #page + ':size:' + #size")
+	public PageResponse<FindPostsByPopularResponse> findPostsByPopular(int page, int size) {
 		PageRequest pageRequest = PageRequest.of(page, size);
 
 		Page<Post> posts = postRepository.findAllByOrderByViewsDesc(pageRequest);
 
-		return posts.map(FindPostsByPopularResponse::from);
+		return PageResponse.from(posts.map(FindPostsByPopularResponse::from));
 	}
 
 	// 글 조회

--- a/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
+++ b/backend/src/main/java/cotato/backend/domains/post/service/PostService.java
@@ -3,6 +3,8 @@ package cotato.backend.domains.post.service;
 import static cotato.backend.common.exception.ErrorCode.*;
 
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
@@ -30,6 +32,7 @@ public class PostService {
 
 	private final PostJDBCRepository postJDBCRepository;
 	private final PostRepository postRepository;
+	private final Map<Long, AtomicInteger> viewCounts;
 
 	// 로컬 파일 경로로부터 엑셀 파일을 읽어 Post 엔터티로 변환하고 저장
 	@Transactional
@@ -62,17 +65,22 @@ public class PostService {
 		postRepository.save(post);
 	}
 
-
 	// 글 조회
 	@Transactional
-	public FindPostByIdResponse findPostById(Long postId) {
+	public FindPostByIdResponse findPostDtoByIdAndIncreaseView(Long postId) {
 		Post post = postRepository.findById(postId)
 			.orElseThrow(() -> ApiException.from(POST_NOT_FOUND));
 
 		// 조회수 증가
-		post.increaseViews();
+		incrementViewCountInCache(postId);
 
 		return FindPostByIdResponse.from(post);
+	}
+
+	// 조회수 증가
+	private void incrementViewCountInCache(Long postId) {
+		viewCounts.computeIfAbsent(postId, id -> new AtomicInteger(0))
+			.incrementAndGet();
 	}
 
 	// 글 삭제
@@ -88,5 +96,11 @@ public class PostService {
 		Page<Post> posts = postRepository.findAllByOrderByViewsDesc(pageRequest);
 
 		return posts.map(FindPostsByPopularResponse::from);
+	}
+
+	// 글 조회
+	public Post findById(Long postId) {
+		return postRepository.findById(postId)
+			.orElseThrow(() -> ApiException.from(POST_NOT_FOUND));
 	}
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=backend


### PR DESCRIPTION
# 문제
- 서비스가 대규모로 확장됨에 따라 여러 성능, 동시성 문제가 발생했습니다.
- 조회 수 증가 로직이 제대로 동작하지 않습니다.
- 인기 게시글 조회 성능이 나빠졌습니다.

- 대규모 데이터를 테스트하려하나 지금의 엑셀 방식은 테스트하기 용이하지 않습니다.

# 구현 사항
## 더미 데이터 생성 로직 변경
![image](https://github.com/user-attachments/assets/4d648eea-c4dd-4c3e-9bb0-63ad626257c1)
기존에는 위와 같이 엑셀을 통해 더미데이터를 넣어주었습니다. 20만 개의 데이터가 있었지만, 데이터 수를 늘러거나 줄이는 것은 쉽지 않았습니다.

그래서 이를 `CommandLineRunner`를 통해  애플리케이션 단에서 편하게 데이터를 초기화할 수 있게 하였습니다.
![image](https://github.com/user-attachments/assets/3f5b06fc-3ea8-4e1e-b2f1-5feed16e5217)

위 `initializeData` 메서드는 애플리케이션이 실행될 때 실행되게 됩니다.(postRepo에 이미 데이터가 있으면 실행되지 않도록 했습니다.)

### 더미 데이터 생성 상황에서의 트러블 슈팅
위 변경 사항대로 로컬에서 저장했을 때에는 정상적으로 저장됐지만, 실제 EC2 `t2.micro`서버에 올려 실행을 시키니 20분뒤 OutOfMemory 에러가 발생함을 알게 되었습니다.

- 로그를 분석한 결과 `initializeData` 메서드를 실행시키는 도중에 문제가 발생함을 알게 되었습니다.

원인 분석
- 50만 개의 데이터를 List에 저장시키고 한번에 DB에 저장시킵니다.
- 50만 개의 데이터가 List에 들어가면서 Memory가 부족해졌습니다.
- 실제 로컬  환경에서는 RAM이 커 감당가능했으나, EC2 `t2.micro` 서버는 RAM이 1GB 밖에 되지 않아 이를  감당할 수 없었습니다.
- 또한 50만 개의 데이터를 JPA를 통해 저장하면 영속성 컨텍스트 또한 과부하가 발생했습니다.

개선
![image](https://github.com/user-attachments/assets/42536af2-ef6e-47a5-a745-089dbf365211)
![image](https://github.com/user-attachments/assets/4fe1cc0d-01a7-45e8-bb33-09762ee651a1)
- 기존의 50만 개의 데이터는 5000번 단위로 끊어서 저장시켰습니다. 저장된 데이터들은 List에서 제외시켰습니다.
- 또한 기존의 JPA로 저장하는 방식에서 JPQL의 BatchUpdate 방식으로 변경했습니다.
- 이로 인해 데이터들은 영속성 컨텍스트에 저장되지 않았고, 또한 Batch로 저장하여 네트워크 통신 횟수를 크게 줄일 수 있었습니다.
### 결과
- 저장 로직 실행시 대략 `20m(이상) -> 21s`로 60배 이상 개선
- 메모리 오류 해결


## 동시성 문제 해결
![image](https://github.com/user-attachments/assets/964f8616-5947-4074-8bda-a71e8dddaafe)
![image](https://github.com/user-attachments/assets/33b7b8d1-ca26-4a46-ba47-2ed0b84305a2)

기존의 조회 수 로직에서 동시성 문제가 발생했습니다.

이에 대한 해결 방법으로 낙관적 락, 비관적 락, 애플리케이션 캐시, 싱글 스레드인 레디스를 통한 해결
등이 존재했습니다.

비교
낙관적 락
- 빠름
- 동시성 문제가 적을 때 사용
비관적 락
- DB에 락을 거므로 성능 저하 발생
- 동시성 문제는 확실히 해결
애플리케이션에서 AtomicInteger를 활용한 방법
- 낙관적  락을 사용할 경우 DB 트랜잭션을 통해 version 정보를 가져와서 처리합니다. 반면 AtomicInteger는 같은 낙관적 락 방식이긴 하나,  하드웨어 내부적으로 CompareAndSwap 방식으로 처리하기에 네트워크 및 트랜잭션 비용이 있는 낙관적 락보다 AtomicInteger가 훨 성능이 좋습니다.

### 적용
위 비교를 통해 애플리케이션에서 AtomicInteger를 활용하여 개선했습니다.
![image](https://github.com/user-attachments/assets/d32e1ade-2148-401c-9441-c6290f2dbc77)
![image](https://github.com/user-attachments/assets/831f899b-3359-4a98-ac1d-0794e3a54666)
![image](https://github.com/user-attachments/assets/696e950c-2f5e-4afd-808b-3302334815d5)


### 결과
- `t2.micro` 기준 동시 접속 150명에서 N천명 까지 안정성을 보장받을 수 있게 됐습니다.
- (N천명부터는 동시성 문제가 아니라 DB 조회 성능으로 인한 에러가 발생했습니다.)


## 조회 성능 개선
50만 개의 데이터를 넣고 인기 게시글 목록 조회시 1000번 부터 성능이 급격하게 나빠짐

인덱싱 적용

### 결과

![image](https://github.com/user-attachments/assets/356bf558-7765-4d9f-bd49-e40d6188850b)
![image](https://github.com/user-attachments/assets/0cf7f9ea-28d4-4294-b068-61662f8689ae)
- 1000번 요청 시 대략 26s -> 7s 로 4배 정도 개선

## 조회 성능 개선 2
인기 게시글 특성 상 인기 많은 게시글이 더 많이 조회되므로 Redis 캐시를 추가하여 성능 개선
![image](https://github.com/user-attachments/assets/a98455be-5ca2-49f5-af5b-7176d144a3e1)


